### PR TITLE
50 cannot take gel boat out of electrolysis setup

### DIFF
--- a/project/source/GelImager.gd
+++ b/project/source/GelImager.gd
@@ -21,15 +21,18 @@ func _on_CloseButton_pressed():
 	$ImagingMenu/GelDisplay.close()
 
 func slot_filled(slot, object):
+	var filled = false
 	if object.is_in_group("Gel Boat"):
 		if object.contents != []:
 			if object.contents[0].is_in_group("Gel"):
 				var init_data = object.gel_status()
+				
 				$ImagingMenu/GelDisplay.init(init_data[0], init_data[1])
 				$ImagingMenu/GelDisplay.update_bands(object.calculate_positions())
 				
 				$ImagingMenu.visible = true
 				$ImagingMenu/GelDisplay.open()
+				filled = true
 			else:
 				print("Container does not contain gel")
 				LabLog.Warn('You tried to image a container without a gel in it.')
@@ -39,6 +42,11 @@ func slot_filled(slot, object):
 	else:
 		print("Cannot insert this container into gel imager")
 		LabLog.Warn('You tried to place a different container into the gel imager instead of the gel boat.')
+	if !filled:
+		$GelBoatSlot.held_object = null
 
 func slot_emptied(slot, object):
-	pass
+	object.visible = true
+	object.position = Vector2(self.position.x, self.position.y - 150)
+	if object.is_in_group("SubsceneManagers"):
+		object.HideSubscene()

--- a/project/source/GelImager.gd
+++ b/project/source/GelImager.gd
@@ -32,6 +32,7 @@ func slot_filled(slot, object):
 				
 				$ImagingMenu.visible = true
 				$ImagingMenu/GelDisplay.open()
+				object.visible = false
 				filled = true
 			else:
 				print("Container does not contain gel")

--- a/project/source/Scenes/Objects/ElectrolysisSetup.tscn
+++ b/project/source/Scenes/Objects/ElectrolysisSetup.tscn
@@ -16,7 +16,7 @@ extents = Vector2( 50, 14.5 )
 extents = Vector2( 10, 9.5 )
 
 [sub_resource type="RectangleShape2D" id=3]
-extents = Vector2( 37.25, 12 )
+extents = Vector2( 65, 30.1875 )
 
 [node name="ElectrolysisSetup" type="RigidBody2D"]
 position = Vector2( -3, 35 )
@@ -173,19 +173,19 @@ position = Vector2( 1, 1 )
 shape = SubResource( 2 )
 
 [node name="GelBoatSlot" type="RigidBody2D" parent="."]
+collision_layer = 3
+input_pickable = true
 gravity_scale = 0.0
 script = ExtResource( 2 )
 
-[node name="CollisionShape2D3" type="CollisionShape2D" parent="GelBoatSlot"]
-position = Vector2( -2.25, -47 )
+[node name="CollisionShape2D" type="CollisionShape2D" parent="GelBoatSlot"]
+position = Vector2( 1, -30.1875 )
 shape = SubResource( 3 )
 
 [node name="Area2D" type="Area2D" parent="GelBoatSlot"]
-input_pickable = false
-monitorable = false
 
-[node name="CollisionShape2D2" type="CollisionShape2D" parent="GelBoatSlot/Area2D"]
-position = Vector2( 1, -47 )
+[node name="CollisionShape2D" type="CollisionShape2D" parent="GelBoatSlot/Area2D"]
+position = Vector2( 2, -30 )
 shape = SubResource( 3 )
 
 [node name="GelButton" type="Button" parent="."]
@@ -217,6 +217,6 @@ texture_normal = ExtResource( 8 )
 [connection signal="pressed" from="FollowMenu/SubstanceMenu/SubstanceCloseButton" to="." method="_on_SubstanceCloseButton_pressed"]
 [connection signal="body_exited" from="PosTerminal/Area2D" to="PosTerminal" method="_on_Area2D_body_exited"]
 [connection signal="body_exited" from="NegTerminal/Area2D" to="NegTerminal" method="_on_Area2D_body_exited"]
-[connection signal="body_exited" from="GelBoatSlot/Area2D" to="GelBoatSlot" method="_on_Area2D_body_exited"]
+[connection signal="input_event" from="GelBoatSlot" to="GelBoatSlot" method="_on_GelBoatSlot_input_event"]
 [connection signal="pressed" from="GelButton" to="." method="_on_GelButton_pressed"]
 [connection signal="pressed" from="GelSimMenu/CloseButton" to="." method="_on_CloseButton_pressed"]

--- a/project/source/Scenes/Objects/ElectrolysisSetup.tscn
+++ b/project/source/Scenes/Objects/ElectrolysisSetup.tscn
@@ -173,7 +173,6 @@ position = Vector2( 1, 1 )
 shape = SubResource( 2 )
 
 [node name="GelBoatSlot" type="RigidBody2D" parent="."]
-collision_layer = 3
 input_pickable = true
 gravity_scale = 0.0
 script = ExtResource( 2 )

--- a/project/source/Scenes/Objects/GelImager.tscn
+++ b/project/source/Scenes/Objects/GelImager.tscn
@@ -74,6 +74,7 @@ size_flags_vertical = 0
 icon = ExtResource( 3 )
 
 [node name="GelBoatSlot" type="RigidBody2D" parent="."]
+input_pickable = true
 gravity_scale = 0.0
 script = ExtResource( 5 )
 
@@ -116,4 +117,4 @@ position = Vector2( -4.0625, 16.25 )
 shape = SubResource( 2 )
 
 [connection signal="pressed" from="ImagingMenu/CloseButton" to="." method="_on_CloseButton_pressed"]
-[connection signal="body_exited" from="GelBoatSlot/Area2D" to="GelBoatSlot" method="_on_Area2D_body_exited"]
+[connection signal="input_event" from="GelBoatSlot" to="GelBoatSlot" method="_on_GelBoatSlot_input_event"]

--- a/project/source/Scripts/Objects/ElectrolysisSetup.gd
+++ b/project/source/Scripts/Objects/ElectrolysisSetup.gd
@@ -106,9 +106,8 @@ func slot_emptied(slot, object):
 		$Sprite.texture = nonfilled_texture
 	else:
 		$Sprite.texture = filled_texture
-	print(mounted_container.position)
+		
 	mounted_container.position = Vector2(self.position.x - 170, self.position.y - 20)
-	print(self.position)
 	mounted_container = null
 
 func _on_SubstanceCloseButton_pressed():

--- a/project/source/Scripts/Objects/ElectrolysisSetup.gd
+++ b/project/source/Scripts/Objects/ElectrolysisSetup.gd
@@ -20,7 +20,6 @@ func TryInteract(others):
 			if len(liquid_substance) > 1:
 				liquid_substance = liquid_substance[0]
 			if(!(liquid_substance)):
-				print(other)
 				return
 			# Open substance menu
 			$FollowMenu/SubstanceMenu.visible = true
@@ -34,7 +33,15 @@ func TryInteract(others):
 					print(fill_substance)
 					$FollowMenu/SubstanceMenu.visible = false
 					# Update the Electrolysis setup to show that it is filled
-					$Sprite.texture = filled_texture
+					if mounted_container != null:
+						if mounted_container.GelMoldInfo()["hasComb"]:
+							$Sprite.texture = filled_comb_texture
+						elif mounted_container.GelMoldInfo()["hasWells"]:
+							$Sprite.texture = filled_wells_texture
+						else:
+							$Sprite.texture = filled_texture
+					else:
+						$Sprite.texture = filled_texture
 				elif(other.CheckContents("Liquid Substance")):
 					print('The setup is already filled.')
 				else:
@@ -99,7 +106,9 @@ func slot_emptied(slot, object):
 		$Sprite.texture = nonfilled_texture
 	else:
 		$Sprite.texture = filled_texture
-	
+	print(mounted_container.position)
+	mounted_container.position = Vector2(self.position.x - 170, self.position.y - 20)
+	print(self.position)
 	mounted_container = null
 
 func _on_SubstanceCloseButton_pressed():

--- a/project/source/Scripts/Objects/ElectrolysisSetup.gd
+++ b/project/source/Scripts/Objects/ElectrolysisSetup.gd
@@ -105,6 +105,11 @@ func slot_emptied(slot, object):
 		return
 	mounted_container.visible = true
 	
+	# We should prevent showing the subscene on removing the gel boat
+	# as that should be done when the user clicks it, not when removing it
+	if mounted_container.is_in_group("SubsceneManagers"):
+		mounted_container.HideSubscene();
+	
 	if fill_substance == null:
 		$Sprite.texture = nonfilled_texture
 	else:

--- a/project/source/Scripts/Objects/ElectrolysisSetup.gd
+++ b/project/source/Scripts/Objects/ElectrolysisSetup.gd
@@ -96,8 +96,11 @@ func slot_filled(slot, object):
 		
 		var init_data = mounted_container.gel_status()
 		$GelSimMenu/GelDisplay.init(init_data[0], init_data[1])
+	else:
+		slot_emptied(slot, object)
 
 func slot_emptied(slot, object):
+	$GelBoatSlot.held_object = null
 	if mounted_container == null:
 		return
 	mounted_container.visible = true

--- a/project/source/Scripts/Objects/LabObject.gd
+++ b/project/source/Scripts/Objects/LabObject.gd
@@ -19,6 +19,8 @@ onready var defaultMode = mode
 onready var defaultZIndex = z_index
 onready var defaultZAsRelative = z_as_relative
 
+var startPosition
+
 func _get_configuration_warning():
 	for child in get_children():
 		if child is CollisionShape2D or child is CollisionPolygon2D:
@@ -39,6 +41,8 @@ func _ready():
 	collision_mask = 1 #Scene layer, no others
 	can_sleep = false
 	input_pickable = true
+	
+	startPosition = self.position
 	
 	#if we're not in the editor
 	if not Engine.editor_hint:
@@ -272,3 +276,6 @@ func ReportAction(objectsInvolved: Array, actionType: String, params: Dictionary
 	params['objectsInvolved'] = objectsInvolved
 	params['actionType'] = actionType
 	GetCurrentModuleScene().CheckAction(params)
+
+func GetStartPosition():
+	return startPosition

--- a/project/source/Scripts/Objects/ObjectSlot.gd
+++ b/project/source/Scripts/Objects/ObjectSlot.gd
@@ -14,8 +14,9 @@ func TryInteract(others):
 				# prevent the area from detecting the single-frame coordinate snap on adding the child
 				$Area2D.monitoring = false
 				
-				GetCurrentModuleScene().call_deferred("remove_child", other)
-				self.call_deferred("add_child", other)
+				if other in GetCurrentModuleScene().get_children():
+					GetCurrentModuleScene().call_deferred("remove_child", other)
+					self.call_deferred("add_child", other)
 				
 				other.set_deferred("position", Vector2.ZERO)
 				
@@ -41,8 +42,9 @@ func _on_GelBoatSlot_input_event(viewport, event, shape_idx):
 		held_object.set_deferred("gravity_scale", saved_grav_scale)
 		held_object.set_deferred("mode", saved_phys_mode)
 
-		self.call_deferred("remove_child", held_object)
-		GetCurrentModuleScene().call_deferred("add_child", held_object)
+		if held_object in self.get_children():
+			self.call_deferred("remove_child", held_object)
+			GetCurrentModuleScene().call_deferred("add_child", held_object)
 
 		get_parent().slot_emptied(self, held_object)
 		held_object = null

--- a/project/source/Scripts/Objects/ObjectSlot.gd
+++ b/project/source/Scripts/Objects/ObjectSlot.gd
@@ -1,53 +1,42 @@
 extends LabObject
 
-export (String) var allowed_group = 'Container'
+export var allowed_groups = ['Container', 'Liquid Container']
 var held_object = null
 var saved_grav_scale = 0.0
 var saved_phys_mode = 0
 
 func TryInteract(others):
 	for other in others:
-		if(other.is_in_group(allowed_group)):
-			if(!filled()):
-				held_object = other
-				
-				# prevent the area from detecting the single-frame coordinate snap on adding the child
-				$Area2D.monitoring = false
-				
-				if other in GetCurrentModuleScene().get_children():
-					GetCurrentModuleScene().call_deferred("remove_child", other)
+		for allowed_group in allowed_groups:
+			if(other.is_in_group(allowed_group)):
+				if(!filled()):
+					held_object = other
+					# prevent the area from detecting the single-frame coordinate snap on adding the child
+					$Area2D.monitoring = false
+					
+					if (other.get_parent()):
+						other.get_parent().call_deferred("remove_child", other)
 					self.call_deferred("add_child", other)
-				
-				other.set_deferred("position", Vector2.ZERO)
-				
-				$Area2D.monitoring = true
-				
-				saved_grav_scale = other.gravity_scale
-				other.set_deferred("gravity_scale", 0.0)
-				saved_phys_mode = other.mode
-				
-				get_parent().slot_filled(self, other)
+					
+					other.set_deferred("position", Vector2.ZERO)
+					
+					$Area2D.monitoring = true
+					
+					get_parent().slot_filled(self, other)
 
 func filled():
 	return (held_object != null)
 
 func get_object():
 	return held_object
-	
-func _on_Area2D_body_exited(body):
-	pass
 
 func _on_GelBoatSlot_input_event(viewport, event, shape_idx):
 	if (event.is_pressed()):
 		if (!filled()):
 			return
 
-		held_object.set_deferred("gravity_scale", saved_grav_scale)
-		held_object.set_deferred("mode", saved_phys_mode)
-
-		if held_object in self.get_children():
-			self.call_deferred("remove_child", held_object)
-			GetCurrentModuleScene().call_deferred("add_child", held_object)
-
+		if (held_object.get_parent()):
+			held_object.get_parent().call_deferred("remove_child", held_object)
+		GetCurrentModuleScene().call_deferred("add_child", held_object)
 		get_parent().slot_emptied(self, held_object)
 		held_object = null

--- a/project/source/Scripts/Objects/ObjectSlot.gd
+++ b/project/source/Scripts/Objects/ObjectSlot.gd
@@ -33,6 +33,9 @@ func filled():
 
 func get_object():
 	return held_object
+	
+func _on_Area2D_body_exited(body):
+	pass
 
 func _on_GelBoatSlot_input_event(viewport, event, shape_idx):
 	if (event.is_pressed()):


### PR DESCRIPTION
It is possible again to remove the gel boat, albeit the functionality to do so was adjusted to rely on a click within the setup instead of trying to drag out an invisible object.

It also fixes issue #95 that causes objects like the erlenmeyer flask to get stuck. It now automatically ejects these objects within the eletrolysis setup script.

There are a couple small issues that remain to be fixed:
- `_on_Area2D_body_exited()` is still being called occasionally even though the function was disconnected
- When taking the gel mold out, it opens the subscene for it