### PR TITLE
Change Gel Imager collision shape to polygon

### DIFF
--- a/project/source/Scenes/Objects/GelImager.tscn
+++ b/project/source/Scenes/Objects/GelImager.tscn
@@ -24,8 +24,6 @@ texture = ExtResource( 2 )
 position = Vector2( -0.5, -29 )
 polygon = PoolVector2Array( 0.5, -125, -66.5, -124, -88.5, -110, -106.5, -30, -104.5, 119, -93.5, 124, 104.5, 122, 106.5, 113, 106.5, -34, 90.5, -111, 71.5, -124 )
 
-[node name="Polygon2D" type="Polygon2D" parent="."]
-
 [node name="ImagingMenu" type="CanvasLayer" parent="."]
 
 [node name="Sprite" type="Sprite" parent="ImagingMenu"]

--- a/project/source/Scenes/Objects/GelImager.tscn
+++ b/project/source/Scenes/Objects/GelImager.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=9 format=2]
+[gd_scene load_steps=8 format=2]
 
 [ext_resource path="res://Scripts/Objects/GelImager.gd" type="Script" id=1]
 [ext_resource path="res://Images/Resized_Images/imager.png" type="Texture" id=2]
@@ -6,9 +6,6 @@
 [ext_resource path="res://Images/GelImagerFront2.png" type="Texture" id=4]
 [ext_resource path="res://Scripts/Objects/ObjectSlot.gd" type="Script" id=5]
 [ext_resource path="res://Scenes/UI/GelDisplay.tscn" type="PackedScene" id=7]
-
-[sub_resource type="RectangleShape2D" id=1]
-extents = Vector2( 53, 44.25 )
 
 [sub_resource type="RectangleShape2D" id=2]
 extents = Vector2( 96.0625, 76.75 )
@@ -23,10 +20,9 @@ script = ExtResource( 1 )
 position = Vector2( 0, -30 )
 texture = ExtResource( 2 )
 
-[node name="CollisionShape2D" type="CollisionShape2D" parent="."]
-visible = false
-position = Vector2( 2, 6.25 )
-shape = SubResource( 1 )
+[node name="CollisionShape2D" type="CollisionPolygon2D" parent="."]
+position = Vector2( -0.5, -29 )
+polygon = PoolVector2Array( 0.5, -125, -66.5, -124, -88.5, -110, -106.5, -30, -104.5, 119, -93.5, 124, 104.5, 122, 106.5, 113, 106.5, -34, 90.5, -111, 71.5, -124 )
 
 [node name="Polygon2D" type="Polygon2D" parent="."]
 
@@ -51,10 +47,11 @@ margin_right = 176.464
 margin_bottom = 211.36
 
 [node name="ColorRect" type="ColorRect" parent="ImagingMenu/PanelContainer"]
-margin_left = 7.0
-margin_top = 7.0
-margin_right = 242.0
-margin_bottom = 198.0
+visible = false
+margin_left = 10.0
+margin_top = 10.0
+margin_right = 239.0
+margin_bottom = 195.0
 color = Color( 0, 0, 0, 1 )
 
 [node name="GelDisplay" parent="ImagingMenu" instance=ExtResource( 7 )]

--- a/project/source/Scenes/UI/GelDisplay.tscn
+++ b/project/source/Scenes/UI/GelDisplay.tscn
@@ -1,8 +1,26 @@
-[gd_scene load_steps=5 format=2]
+[gd_scene load_steps=8 format=2]
 
 [ext_resource path="res://Images/Gel_Wells.png" type="Texture" id=1]
 [ext_resource path="res://Scripts/UI/GelDisplay.gd" type="Script" id=2]
 [ext_resource path="res://Images/redX.png" type="Texture" id=3]
+
+[sub_resource type="StyleBoxFlat" id=2]
+bg_color = Color( 1, 0.384314, 0.384314, 1 )
+border_width_left = 1
+border_width_bottom = 1
+border_color = Color( 1, 1, 1, 1 )
+
+[sub_resource type="StyleBoxFlat" id=3]
+bg_color = Color( 0.72549, 0.156863, 0.156863, 1 )
+border_width_left = 1
+border_width_bottom = 1
+border_color = Color( 1, 1, 1, 1 )
+
+[sub_resource type="StyleBoxFlat" id=4]
+bg_color = Color( 1, 0.215686, 0.215686, 1 )
+border_width_left = 1
+border_width_bottom = 1
+border_color = Color( 1, 1, 1, 1 )
 
 [sub_resource type="RectangleShape2D" id=1]
 extents = Vector2( 220, 17 )
@@ -19,6 +37,24 @@ margin_left = -225.0
 margin_top = -271.0
 margin_right = 225.0
 margin_bottom = 268.0
+rect_pivot_offset = Vector2( 377, -18 )
+
+[node name="CloseButton" type="Button" parent="Panel"]
+anchor_left = 1.0
+anchor_right = 1.0
+margin_left = -40.0
+margin_bottom = 40.0
+custom_colors/font_color_disabled = Color( 0.65098, 0.65098, 0.65098, 1 )
+custom_colors/font_color_focus = Color( 1, 1, 1, 1 )
+custom_colors/font_color = Color( 1, 1, 1, 1 )
+custom_colors/font_color_hover = Color( 1, 1, 1, 1 )
+custom_colors/font_color_pressed = Color( 1, 1, 1, 1 )
+custom_styles/hover = SubResource( 2 )
+custom_styles/pressed = SubResource( 3 )
+custom_styles/focus = SubResource( 4 )
+custom_styles/disabled = SubResource( 3 )
+custom_styles/normal = SubResource( 4 )
+text = "X"
 
 [node name="Gel" type="Sprite" parent="."]
 position = Vector2( 1, -2 )
@@ -82,6 +118,7 @@ margin_bottom = -253.0
 rect_scale = Vector2( 2, 2 )
 texture_normal = ExtResource( 3 )
 
+[connection signal="pressed" from="Panel/CloseButton" to="." method="_on_CloseButton_pressed"]
 [connection signal="pressed" from="UVLightButton" to="." method="_on_UVLightButton_pressed"]
 [connection signal="body_entered" from="TopRunoffArea" to="." method="_on_TopRunoffArea_body_entered"]
 [connection signal="body_entered" from="BottomRunoffArea" to="." method="_on_BottomRunoffArea_body_entered"]

--- a/project/source/Scripts/Objects/LabObject.gd
+++ b/project/source/Scripts/Objects/LabObject.gd
@@ -155,7 +155,7 @@ func GetIntersectingLabObjects():
 	#For each collider that we have, see if it colllides with anything.
 	#This way, we could have LabObjects with multiple colliders on them (for example, multiple rectangles making up a more complex shape)
 	for child in get_children():
-		if child is CollisionShape2D or child is CollisionPolygon2D:
+		if child is CollisionShape2D:
 			var queryOptions = Physics2DShapeQueryParameters.new()
 			queryOptions.set_shape(child.shape)
 			queryOptions.transform = child.get_global_transform()


### PR DESCRIPTION
This makes the collision shape for the `GelImager` to be a `CollisionPolygon2D`. This makes it easier to click on the object so that the image appears or disappears.

This lead to an issue I found within `LabObject.gd` in the function `GetIntersectingLabObjects()`. It would crash from the line `queryOptions.set_shape(child.shape)`.

The fix I opted for removed the check if the child is `CollisionPolygon2D` since it does not have the property `shape`. Instead, it has a `polygon` property which is of type `PackedVector2Array`.

As you are more familiar with the base `LabObject` class, I feel you would have a better understanding of this and will let you decide if I am wrong in this decision or if you know of a way to set the shape within `queryOptions` to be of this type.