### PR TITLE
Changed Project settings to account for resizing of the window

### DIFF
--- a/project/source/project.godot
+++ b/project/source/project.godot
@@ -29,7 +29,8 @@ gdscript/warnings/untyped_declaration=2
 
 window/size/viewport_width=1280
 window/size/viewport_height=720
-window/stretch/mode="2d"
+window/stretch/mode="canvas_items"
+window/stretch/aspect="ignore"
 
 [gui]
 


### PR DESCRIPTION
The scenes will always take up the entire window space.

Closes #244 