### PR TITLE
Fix the `editor/export/editor_export.cpp:225` error that appears on startup

### DIFF
--- a/project/source/export_presets.cfg
+++ b/project/source/export_presets.cfg
@@ -1,7 +1,7 @@
 [preset.0]
 
-name="HTML5"
-platform="HTML5"
+name="Web"
+platform="Web"
 runnable=true
 custom_features=""
 export_filter="all_resources"


### PR DESCRIPTION
This was fixed by changing the `"HTML5"` presets to `"Web"`, since this was changed in 4.3. I found the solution to this on [this](https://github.com/godotengine/godot/issues/89023) issue on the godot github.