### PR TITLE
Stop automatically loading the gel lab and fix some other issues

### DIFF
--- a/project/source/Scenes/Logger/MistakeChecker.tscn
+++ b/project/source/Scenes/Logger/MistakeChecker.tscn
@@ -1,6 +1,6 @@
-[gd_scene load_steps=2 format=2]
+[gd_scene load_steps=2 format=3 uid="uid://c53boitqnhd0l"]
 
-[ext_resource path="res://Scripts/Resources/MistakeChecker.gd" type="Script" id=1]
+[ext_resource type="Script" path="res://Scripts/Resources/MistakeChecker.gd" id="1"]
 
 [node name="MistakeChecker" type="Node2D"]
-script = ExtResource( 1 )
+script = ExtResource("1")

--- a/project/source/Scenes/Modules/GelElectrophoresis.tscn
+++ b/project/source/Scenes/Modules/GelElectrophoresis.tscn
@@ -4,22 +4,22 @@
 [ext_resource type="Texture2D" uid="uid://dfinou685yv2a" path="res://Images/Resized_Images/Pipette_holder.png" id="2"]
 [ext_resource type="Script" path="res://Scripts/Resources/MistakeChecker.gd" id="2_26cga"]
 [ext_resource type="PackedScene" path="res://Scenes/Objects/LabContainer.tscn" id="3"]
-[ext_resource type="PackedScene" path="res://Scenes/Objects/SourceContainer.tscn" id="4"]
+[ext_resource type="PackedScene" uid="uid://cowfxnf6s31pm" path="res://Scenes/Objects/SourceContainer.tscn" id="4"]
 [ext_resource type="PackedScene" uid="uid://cdrtd40n83ytx" path="res://Scenes/Objects/Scoopula.tscn" id="5"]
 [ext_resource type="PackedScene" path="res://Scenes/Substances/GelModule/BinderSubstance.tscn" id="6"]
 [ext_resource type="PackedScene" uid="uid://drmdj4df5uwn7" path="res://Scenes/Objects/Microwave.tscn" id="7"]
 [ext_resource type="Texture2D" uid="uid://bwkmd8uade2g6" path="res://Images/Resized_Images/TEA_Buffer.png" id="8"]
 [ext_resource type="PackedScene" uid="uid://bdfkn4vc3t1ld" path="res://Scenes/Objects/Scale.tscn" id="9"]
-[ext_resource type="PackedScene" path="res://Scenes/Objects/WeighBoat.tscn" id="10"]
+[ext_resource type="PackedScene" uid="uid://bx4lalohf7clg" path="res://Scenes/Objects/WeighBoat.tscn" id="10"]
 [ext_resource type="PackedScene" path="res://Scenes/Objects/Pipettes/P1000.tscn" id="11"]
 [ext_resource type="Texture2D" uid="uid://c16pk6aqn5d2t" path="res://Images/Resized_Images/Agarose_Powder.png" id="12"]
-[ext_resource type="PackedScene" path="res://Scenes/Objects/GraduatedCylinder.tscn" id="13"]
+[ext_resource type="PackedScene" uid="uid://cpax3ed6lg0e2" path="res://Scenes/Objects/GraduatedCylinder.tscn" id="13"]
 [ext_resource type="PackedScene" path="res://Scenes/Substances/GelModule/AgarPowderSubstance.tscn" id="14"]
 [ext_resource type="Script" path="res://Scripts/Substances/GelModule/GelMixManager.gd" id="15"]
 [ext_resource type="Texture2D" uid="uid://evoowj21iule" path="res://Images/Resized_Images/microcentrifuge_rack_BACK.png" id="16"]
 [ext_resource type="PackedScene" path="res://Scenes/Objects/SharpsDisposal.tscn" id="17"]
 [ext_resource type="Texture2D" uid="uid://b44fdogq3thf6" path="res://Images/Resized_Images/microcentrifuge_rack_FRONT.png" id="18"]
-[ext_resource type="PackedScene" path="res://Scenes/Objects/GelMoldSubsceneManager.tscn" id="19"]
+[ext_resource type="PackedScene" uid="uid://ox8tkk7nhjvu" path="res://Scenes/Objects/GelMoldSubsceneManager.tscn" id="19"]
 [ext_resource type="PackedScene" path="res://Scenes/Objects/TipBox.tscn" id="20"]
 [ext_resource type="PackedScene" uid="uid://dbm4rpbhs7wdc" path="res://Scenes/Objects/ElectrolysisSetup.tscn" id="21"]
 [ext_resource type="Script" path="res://Scripts/Substances/GelModule/DNASubstance.gd" id="22"]
@@ -121,14 +121,12 @@ draggable = true
 
 [node name="AgaroseSourceContainer" parent="." instance=ExtResource("4")]
 position = Vector2(671, 854)
-lock_rotation = true
 image = ExtResource("12")
 substance = ExtResource("14")
 display_name = "Agarose"
 
 [node name="TAESourceContainer" parent="." instance=ExtResource("4")]
 position = Vector2(735, 851)
-lock_rotation = true
 image = ExtResource("8")
 substance = ExtResource("6")
 display_name = "TAE Buffer"
@@ -190,7 +188,6 @@ texture = ExtResource("16")
 
 [node name="DNAContainer" parent="DNA Containers" instance=ExtResource("4")]
 position = Vector2(-42, -1.07288e-06)
-lock_rotation = true
 container_type = 1
 substance = SubResource("2")
 substance_parameters = Array[float]([1500.0, 200.0])
@@ -198,7 +195,6 @@ display_name = "DNA 1"
 
 [node name="DNAContainer2" parent="DNA Containers" instance=ExtResource("4")]
 position = Vector2(-16, -1.07288e-06)
-lock_rotation = true
 container_type = 1
 substance = SubResource("2")
 substance_parameters = Array[float]([7500.0, 2200.0, 300.0])
@@ -206,7 +202,6 @@ display_name = "DNA 2"
 
 [node name="DNAContainer3" parent="DNA Containers" instance=ExtResource("4")]
 position = Vector2(9.99999, -9.53674e-07)
-lock_rotation = true
 container_type = 1
 substance = SubResource("2")
 substance_parameters = Array[float]([10000.0])
@@ -214,7 +209,6 @@ display_name = "DNA 3"
 
 [node name="DNAContainer4" parent="DNA Containers" instance=ExtResource("4")]
 position = Vector2(37, -9.53674e-07)
-lock_rotation = true
 container_type = 1
 substance = SubResource("2")
 substance_parameters = Array[float]([20000.0, 10000.0, 7000.0, 5000.0, 4000.0, 3000.0, 2000.0, 1500.0, 1000.0, 700.0, 500.0, 400.0, 300.0, 200.0, 75.0])
@@ -238,4 +232,3 @@ gravity_scale = 1.0
 
 [node name="GelMold" parent="." instance=ExtResource("19")]
 position = Vector2(498, 1083)
-lock_rotation = true

--- a/project/source/Scripts/Objects/Scale.gd
+++ b/project/source/Scripts/Objects/Scale.gd
@@ -1,4 +1,4 @@
-extends "res://Scripts/Objects/LabObject.gd"
+extends LabObject
 
 var has_non_empty_weigh_boat: bool = false
 var tare_weight: float = 0.0

--- a/project/source/Scripts/Substances/GelModule/AgarPowderSubstance.gd
+++ b/project/source/Scripts/Substances/GelModule/AgarPowderSubstance.gd
@@ -1,4 +1,4 @@
-extends "res://Scripts/Substances/Substance.gd"
+extends Substance
 
 # This represents the powdered agarose that makes up one part of the gel.
 

--- a/project/source/Scripts/Substances/GelModule/BinderSubstance.gd
+++ b/project/source/Scripts/Substances/GelModule/BinderSubstance.gd
@@ -1,4 +1,4 @@
-extends "res://Scripts/Substances/Substance.gd"
+extends Substance
 
 # This represents the binder solution that makes up one part of the gel.
 

--- a/project/source/Scripts/Substances/GelModule/DNASubstance.gd
+++ b/project/source/Scripts/Substances/GelModule/DNASubstance.gd
@@ -1,4 +1,4 @@
-extends "res://Scripts/Substances/Substance.gd"
+extends Substance
 class_name DNASubstance
 
 #export (Array) var particle_sizes = [1,1.3,1.7,3]

--- a/project/source/Scripts/Substances/GelModule/GelMixManager.gd
+++ b/project/source/Scripts/Substances/GelModule/GelMixManager.gd
@@ -1,5 +1,5 @@
 # TODO: I think this should be "res://Scripts/Substances/GelModule/GelMixManager.gd but I need to confrim
-extends "res://Scripts/UI/MixManager.gd"
+extends MixManager
 
 # This is the mix manager for the Gel Electrophoresis lab module.
 

--- a/project/source/Scripts/UI/Menu.gd
+++ b/project/source/Scripts/UI/Menu.gd
@@ -37,7 +37,7 @@ func _ready() -> void:
 	# Due to having one module, the MainMenu should be hidden by default
 	# When more modules are added, it is likely a good idea to show MainMenu by default
 	$MainMenu.show()
-	$ModuleSelect.show()
+	$ModuleSelect.hide()
 	$OptionsScreen.hide()
 	$AboutScreen.hide()
 	$LogButton.hide() #until we load a module
@@ -66,8 +66,8 @@ func _ready() -> void:
 	$LogButton/LogMenu.set_tab_icon(3, load("res://Images/Dot-Red.png"))
 	
 	# Since there is one module, it should boot directly into this scene
-	var module: ModuleData = load(module_directory + "GelElectrophoresis.tres")
-	module_selected(module)
+	#var module: ModuleData = load(module_directory + "GelElectrophoresis.tres")
+	#module_selected(module)
 
 # Called every frame. 'delta' is the elapsed time since the previous frame.
 func _process(delta: float) -> void:
@@ -97,6 +97,7 @@ func module_selected(module: ModuleData) -> void:
 	current_module = module
 	$LogButton.show()
 	$LogButton/LogMenu/Instructions.text = module.instructions_bb_code
+	$LogButton/LogMenu/Instructions.show()
 
 func _on_SelectModuleButton_pressed() -> void:
 	$MainMenu.hide()

--- a/project/source/Scripts/UI/MixManager.gd
+++ b/project/source/Scripts/UI/MixManager.gd
@@ -1,4 +1,5 @@
 extends Node
+class_name MixManager
 
 # This object exists in the background of a module and provides a way to 
 # centrally control substance mixing. It should be extended on a per-module 


### PR DESCRIPTION
**The contents of this PR were made by Mari.**

Resolves #221

Changes:
- The gel lab is no longer automatically loaded immediately.
- The lab instructions don't need to be toggled anymore.
- Some `extends` have been changed so they don't specify the full path.