### PR TITLE
Clean up menu navigation

### DIFF
--- a/project/source/Main.gd
+++ b/project/source/Main.gd
@@ -10,12 +10,18 @@ func check_action(params: Dictionary) -> void:
 	for strategy in check_strategies:
 		strategy.check_action(params)
 
-#instanciates scene and adds it as a child of $Scene. Gets rid of any scene that's already been loaded, and hides the menu.
-func set_scene(scene: PackedScene) -> void:
+func _unload_current_module() -> void:
 	LabLog.clear_logs()
 	for child in $Scene.get_children():
 		child.queue_free()
-	
+
+func return_to_menu() -> void:
+	_unload_current_module()
+	current_module_scene = null
+
+#instanciates scene and adds it as a child of $Scene. Gets rid of any scene that's already been loaded, and hides the menu.
+func set_scene(scene: PackedScene) -> void:
+	_unload_current_module()
 	var new_scene := scene.instantiate()
 	$Scene.add_child(new_scene)
 	current_module_scene = new_scene

--- a/project/source/Main.gd
+++ b/project/source/Main.gd
@@ -10,18 +10,14 @@ func check_action(params: Dictionary) -> void:
 	for strategy in check_strategies:
 		strategy.check_action(params)
 
-func _unload_current_module() -> void:
+func unload_current_module() -> void:
 	LabLog.clear_logs()
 	for child in $Scene.get_children():
 		child.queue_free()
 
-func return_to_menu() -> void:
-	_unload_current_module()
-	current_module_scene = null
-
 #instanciates scene and adds it as a child of $Scene. Gets rid of any scene that's already been loaded, and hides the menu.
 func set_scene(scene: PackedScene) -> void:
-	_unload_current_module()
+	unload_current_module()
 	var new_scene := scene.instantiate()
 	$Scene.add_child(new_scene)
 	current_module_scene = new_scene

--- a/project/source/Main.tscn
+++ b/project/source/Main.tscn
@@ -67,18 +67,8 @@ check_strategies = Array[ExtResource("2_45sle")]([ExtResource("9")])
 layer = 128
 script = ExtResource("1")
 
-[node name="MainMenu" type="Control" parent="Menu"]
-layout_mode = 3
+[node name="Background" type="TextureRect" parent="Menu"]
 anchors_preset = 8
-anchor_left = 0.5
-anchor_top = 0.5
-anchor_right = 0.5
-anchor_bottom = 0.5
-grow_horizontal = 2
-grow_vertical = 2
-
-[node name="Background" type="TextureRect" parent="Menu/MainMenu"]
-layout_mode = 0
 anchor_left = 0.5
 anchor_top = 0.5
 anchor_right = 0.5
@@ -89,7 +79,25 @@ offset_right = 640.0
 offset_bottom = 360.0
 texture = ExtResource("3")
 
-[node name="Content" type="VBoxContainer" parent="Menu/MainMenu"]
+[node name="MenuPages" type="Control" parent="Menu"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="MainMenu" type="Control" parent="Menu/MenuPages"]
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="Content" type="VBoxContainer" parent="Menu/MenuPages/MainMenu"]
 layout_mode = 0
 anchor_left = 0.5
 anchor_top = 0.5
@@ -100,7 +108,7 @@ offset_top = -96.5
 offset_right = 200.0
 offset_bottom = 96.5
 
-[node name="Logo" type="TextureRect" parent="Menu/MainMenu/Content"]
+[node name="Logo" type="TextureRect" parent="Menu/MenuPages/MainMenu/Content"]
 visible = false
 custom_minimum_size = Vector2(400, 100)
 layout_mode = 2
@@ -108,26 +116,27 @@ texture = ExtResource("11")
 expand_mode = 1
 stretch_mode = 7
 
-[node name="SelectModuleButton" type="Button" parent="Menu/MainMenu/Content"]
+[node name="SelectModuleButton" type="Button" parent="Menu/MenuPages/MainMenu/Content"]
 layout_mode = 2
 theme_override_fonts/font = ExtResource("12")
 text = "Select Module"
 
-[node name="OptionsButton" type="Button" parent="Menu/MainMenu/Content"]
+[node name="OptionsButton" type="Button" parent="Menu/MenuPages/MainMenu/Content"]
 layout_mode = 2
 theme_override_fonts/font = ExtResource("12")
 text = "Options"
 
-[node name="AboutButton" type="Button" parent="Menu/MainMenu/Content"]
+[node name="AboutButton" type="Button" parent="Menu/MenuPages/MainMenu/Content"]
 layout_mode = 2
 theme_override_fonts/font = ExtResource("12")
 text = "About"
 
-[node name="ExitModuleButton" type="Button" parent="Menu/MainMenu/Content"]
+[node name="ExitModuleButton" type="Button" parent="Menu/MenuPages/MainMenu/Content"]
 layout_mode = 2
 text = "Return to Main Menu"
 
-[node name="ModuleSelect" type="GridContainer" parent="Menu"]
+[node name="ModuleSelect" type="GridContainer" parent="Menu/MenuPages"]
+layout_mode = 1
 anchors_preset = 13
 anchor_left = 0.5
 anchor_right = 0.5
@@ -136,8 +145,9 @@ grow_horizontal = 2
 grow_vertical = 2
 columns = 3
 
-[node name="AboutScreen" type="PanelContainer" parent="Menu"]
+[node name="AboutScreen" type="PanelContainer" parent="Menu/MenuPages"]
 visible = false
+layout_mode = 1
 anchors_preset = 8
 anchor_left = 0.5
 anchor_top = 0.5
@@ -146,18 +156,18 @@ anchor_bottom = 0.5
 offset_left = -400.0
 offset_top = -235.0
 offset_right = 400.0
-offset_bottom = 235.0
+offset_bottom = 240.0
 
-[node name="VBoxContainer" type="VBoxContainer" parent="Menu/AboutScreen"]
+[node name="VBoxContainer" type="VBoxContainer" parent="Menu/MenuPages/AboutScreen"]
 layout_mode = 2
 
-[node name="Label" type="Label" parent="Menu/AboutScreen/VBoxContainer"]
+[node name="Label" type="Label" parent="Menu/MenuPages/AboutScreen/VBoxContainer"]
 custom_minimum_size = Vector2(0, 20)
 layout_mode = 2
 text = "About"
 horizontal_alignment = 1
 
-[node name="Text" type="RichTextLabel" parent="Menu/AboutScreen/VBoxContainer"]
+[node name="Text" type="RichTextLabel" parent="Menu/MenuPages/AboutScreen/VBoxContainer"]
 custom_minimum_size = Vector2(600, 400)
 layout_mode = 2
 bbcode_enabled = true
@@ -403,12 +413,13 @@ The following tools, projects, and assets are used under their respective licens
 									   See the License for the specific language governing permissions and
 									   limitations under the License."
 
-[node name="CloseButton" type="Button" parent="Menu/AboutScreen/VBoxContainer"]
+[node name="CloseButton" type="Button" parent="Menu/MenuPages/AboutScreen/VBoxContainer"]
 layout_mode = 2
 text = "Close"
 
-[node name="OptionsScreen" type="PanelContainer" parent="Menu"]
+[node name="OptionsScreen" type="PanelContainer" parent="Menu/MenuPages"]
 visible = false
+layout_mode = 1
 anchors_preset = 8
 anchor_left = 0.5
 anchor_top = 0.5
@@ -419,37 +430,37 @@ offset_top = -84.5
 offset_right = 150.0
 offset_bottom = 84.5
 
-[node name="VBoxContainer" type="VBoxContainer" parent="Menu/OptionsScreen"]
+[node name="VBoxContainer" type="VBoxContainer" parent="Menu/MenuPages/OptionsScreen"]
 layout_mode = 2
 
-[node name="Label" type="Label" parent="Menu/OptionsScreen/VBoxContainer"]
+[node name="Label" type="Label" parent="Menu/MenuPages/OptionsScreen/VBoxContainer"]
 custom_minimum_size = Vector2(0, 20)
 layout_mode = 2
 text = "Options"
 horizontal_alignment = 1
 
-[node name="MouseDragToggle" type="CheckButton" parent="Menu/OptionsScreen/VBoxContainer"]
+[node name="MouseDragToggle" type="CheckButton" parent="Menu/MenuPages/OptionsScreen/VBoxContainer"]
 visible = false
 layout_mode = 2
 text = "Enable Dragging Camera3D with Mouse"
 
-[node name="ObjectTooltipsToggle" type="CheckButton" parent="Menu/OptionsScreen/VBoxContainer"]
+[node name="ObjectTooltipsToggle" type="CheckButton" parent="Menu/MenuPages/OptionsScreen/VBoxContainer"]
 layout_mode = 2
 text = "Object Tooltips"
 
-[node name="PopupDuration" type="HSplitContainer" parent="Menu/OptionsScreen/VBoxContainer"]
+[node name="PopupDuration" type="HSplitContainer" parent="Menu/MenuPages/OptionsScreen/VBoxContainer"]
 layout_mode = 2
 
-[node name="PopupDurationTitle" type="Label" parent="Menu/OptionsScreen/VBoxContainer/PopupDuration"]
+[node name="PopupDurationTitle" type="Label" parent="Menu/MenuPages/OptionsScreen/VBoxContainer/PopupDuration"]
 layout_mode = 2
 text = "Popup Duration"
 
-[node name="PopupTimeout" type="SpinBox" parent="Menu/OptionsScreen/VBoxContainer/PopupDuration"]
+[node name="PopupTimeout" type="SpinBox" parent="Menu/MenuPages/OptionsScreen/VBoxContainer/PopupDuration"]
 layout_mode = 2
 max_value = 5.0
 step = 0.5
 
-[node name="CloseButton" type="Button" parent="Menu/OptionsScreen/VBoxContainer"]
+[node name="CloseButton" type="Button" parent="Menu/MenuPages/OptionsScreen/VBoxContainer"]
 layout_mode = 2
 text = "Close"
 
@@ -646,15 +657,15 @@ editor_only = false
 position = Vector2(-2, -2)
 script = ExtResource("10")
 
-[connection signal="pressed" from="Menu/MainMenu/Content/SelectModuleButton" to="Menu" method="_on_SelectModuleButton_pressed"]
-[connection signal="pressed" from="Menu/MainMenu/Content/OptionsButton" to="Menu" method="_on_OptionsButton_pressed"]
-[connection signal="pressed" from="Menu/MainMenu/Content/AboutButton" to="Menu" method="_on_AboutButton_pressed"]
-[connection signal="pressed" from="Menu/MainMenu/Content/ExitModuleButton" to="Menu" method="_on_exit_module_button_pressed"]
-[connection signal="pressed" from="Menu/AboutScreen/VBoxContainer/CloseButton" to="Menu" method="_on_About_CloseButton_pressed"]
-[connection signal="toggled" from="Menu/OptionsScreen/VBoxContainer/MouseDragToggle" to="Menu" method="_on_MouseDragToggle_toggled"]
-[connection signal="toggled" from="Menu/OptionsScreen/VBoxContainer/ObjectTooltipsToggle" to="Menu" method="_on_ObjectTooltipsToggle_toggled"]
-[connection signal="value_changed" from="Menu/OptionsScreen/VBoxContainer/PopupDuration/PopupTimeout" to="Menu" method="_on_PopupTimeout_value_changed"]
-[connection signal="pressed" from="Menu/OptionsScreen/VBoxContainer/CloseButton" to="Menu" method="_on_CloseButton_pressed"]
+[connection signal="pressed" from="Menu/MenuPages/MainMenu/Content/SelectModuleButton" to="Menu" method="_on_SelectModuleButton_pressed"]
+[connection signal="pressed" from="Menu/MenuPages/MainMenu/Content/OptionsButton" to="Menu" method="_on_OptionsButton_pressed"]
+[connection signal="pressed" from="Menu/MenuPages/MainMenu/Content/AboutButton" to="Menu" method="_on_AboutButton_pressed"]
+[connection signal="pressed" from="Menu/MenuPages/MainMenu/Content/ExitModuleButton" to="Menu" method="_on_exit_module_button_pressed"]
+[connection signal="pressed" from="Menu/MenuPages/AboutScreen/VBoxContainer/CloseButton" to="Menu" method="_on_About_CloseButton_pressed"]
+[connection signal="toggled" from="Menu/MenuPages/OptionsScreen/VBoxContainer/MouseDragToggle" to="Menu" method="_on_MouseDragToggle_toggled"]
+[connection signal="toggled" from="Menu/MenuPages/OptionsScreen/VBoxContainer/ObjectTooltipsToggle" to="Menu" method="_on_ObjectTooltipsToggle_toggled"]
+[connection signal="value_changed" from="Menu/MenuPages/OptionsScreen/VBoxContainer/PopupDuration/PopupTimeout" to="Menu" method="_on_PopupTimeout_value_changed"]
+[connection signal="pressed" from="Menu/MenuPages/OptionsScreen/VBoxContainer/CloseButton" to="Menu" method="_on_CloseButton_pressed"]
 [connection signal="pressed" from="Menu/FinalReport/VBoxContainer/HBoxContainer/MainMenuButton" to="Menu" method="_on_FinalReport_MainMenuButton_pressed"]
 [connection signal="pressed" from="Menu/FinalReport/VBoxContainer/HBoxContainer/RestartModuleButton" to="Menu" method="_on_FinalReport_RestartModuleButton_pressed"]
 [connection signal="pressed" from="Menu/FinalReport/VBoxContainer/HBoxContainer/ContinueButton" to="Menu" method="_on_FinalReport_ContinueButton_pressed"]

--- a/project/source/Main.tscn
+++ b/project/source/Main.tscn
@@ -122,10 +122,12 @@ theme_override_fonts/font = ExtResource("12")
 text = "Select Module"
 
 [node name="RestartModuleButton" type="Button" parent="Menu/MenuPages/PauseMenu/Content"]
+visible = false
 layout_mode = 2
 text = "Restart Module"
 
 [node name="ExitModuleButton" type="Button" parent="Menu/MenuPages/PauseMenu/Content"]
+visible = false
 layout_mode = 2
 text = "Return to Main Menu"
 
@@ -142,16 +144,6 @@ text = "About"
 [node name="QuitButton" type="Button" parent="Menu/MenuPages/PauseMenu/Content"]
 layout_mode = 2
 text = "Quit"
-
-[node name="ModuleSelect" type="GridContainer" parent="Menu/MenuPages"]
-layout_mode = 1
-anchors_preset = 13
-anchor_left = 0.5
-anchor_right = 0.5
-anchor_bottom = 1.0
-grow_horizontal = 2
-grow_vertical = 2
-columns = 3
 
 [node name="AboutScreen" type="PanelContainer" parent="Menu/MenuPages"]
 visible = false
@@ -472,6 +464,47 @@ step = 0.5
 layout_mode = 2
 text = "Close"
 
+[node name="ModuleSelect" type="PanelContainer" parent="Menu/MenuPages"]
+visible = false
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -10.0
+offset_top = -10.0
+offset_right = 10.0
+offset_bottom = 10.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="VBoxContainer" type="VBoxContainer" parent="Menu/MenuPages/ModuleSelect"]
+layout_mode = 2
+
+[node name="Label" type="Label" parent="Menu/MenuPages/ModuleSelect/VBoxContainer"]
+layout_mode = 2
+text = "Modules"
+horizontal_alignment = 1
+
+[node name="ScrollContainer" type="ScrollContainer" parent="Menu/MenuPages/ModuleSelect/VBoxContainer"]
+custom_minimum_size = Vector2(0, 200)
+layout_mode = 2
+horizontal_scroll_mode = 0
+
+[node name="Modules" type="GridContainer" parent="Menu/MenuPages/ModuleSelect/VBoxContainer/ScrollContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+columns = 3
+
+[node name="Blank" type="Control" parent="Menu/MenuPages/ModuleSelect/VBoxContainer"]
+custom_minimum_size = Vector2(0, 20)
+layout_mode = 2
+
+[node name="CloseButton" type="Button" parent="Menu/MenuPages/ModuleSelect/VBoxContainer"]
+layout_mode = 2
+text = "Close"
+
 [node name="FinalReport" type="PanelContainer" parent="Menu"]
 visible = false
 anchors_preset = 8
@@ -676,6 +709,7 @@ script = ExtResource("10")
 [connection signal="toggled" from="Menu/MenuPages/OptionsScreen/VBoxContainer/ObjectTooltipsToggle" to="Menu" method="_on_ObjectTooltipsToggle_toggled"]
 [connection signal="value_changed" from="Menu/MenuPages/OptionsScreen/VBoxContainer/PopupDuration/PopupTimeout" to="Menu" method="_on_PopupTimeout_value_changed"]
 [connection signal="pressed" from="Menu/MenuPages/OptionsScreen/VBoxContainer/CloseButton" to="Menu" method="_on_CloseButton_pressed"]
+[connection signal="pressed" from="Menu/MenuPages/ModuleSelect/VBoxContainer/CloseButton" to="Menu" method="_on_module_select_close_button_pressed"]
 [connection signal="pressed" from="Menu/FinalReport/VBoxContainer/HBoxContainer/MainMenuButton" to="Menu" method="_on_FinalReport_MainMenuButton_pressed"]
 [connection signal="pressed" from="Menu/FinalReport/VBoxContainer/HBoxContainer/RestartModuleButton" to="Menu" method="_on_FinalReport_RestartModuleButton_pressed"]
 [connection signal="pressed" from="Menu/FinalReport/VBoxContainer/HBoxContainer/ContinueButton" to="Menu" method="_on_FinalReport_ContinueButton_pressed"]

--- a/project/source/Main.tscn
+++ b/project/source/Main.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=18 format=3 uid="uid://ch4jildorp0b3"]
+[gd_scene load_steps=17 format=3 uid="uid://ch4jildorp0b3"]
 
 [ext_resource type="Script" path="res://Scripts/UI/Menu.gd" id="1"]
 [ext_resource type="Script" path="res://Main.gd" id="2"]
@@ -13,7 +13,6 @@
 [ext_resource type="Script" path="res://Mixtures.gd" id="10"]
 [ext_resource type="Texture2D" uid="uid://du4e2yowlkqv0" path="res://Images/VIABLE_Logo_Transparent.png" id="11"]
 [ext_resource type="FontFile" path="res://UI/RobotoMedium28.tres" id="12"]
-[ext_resource type="Script" path="res://Scenes/Modules/exit_module_button.gd" id="13_v23vn"]
 
 [sub_resource type="StyleBoxFlat" id="1"]
 content_margin_left = 10.0
@@ -123,6 +122,10 @@ text = "Options"
 layout_mode = 2
 theme_override_fonts/font = ExtResource("12")
 text = "About"
+
+[node name="ExitModuleButton" type="Button" parent="Menu/MainMenu/Content"]
+layout_mode = 2
+text = "Return to Main Menu"
 
 [node name="ModuleSelect" type="GridContainer" parent="Menu"]
 anchors_preset = 13
@@ -593,22 +596,6 @@ bbcode_enabled = true
 selection_enabled = true
 metadata/_tab_index = 3
 
-[node name="Exit Module" type="RichTextLabel" parent="Menu/LogButton/LogMenu"]
-visible = false
-layout_mode = 2
-metadata/_tab_index = 4
-
-[node name="Node2D" type="Node2D" parent="Menu/LogButton/LogMenu/Exit Module"]
-position = Vector2(212, 51)
-script = ExtResource("13_v23vn")
-
-[node name="ExitModuleButton" type="Button" parent="Menu/LogButton/LogMenu/Exit Module/Node2D"]
-offset_left = -63.0
-offset_top = 52.0
-offset_right = 75.0
-offset_bottom = 79.0
-text = "Exit Module"
-
 [node name="LabLogPopup" type="Control" parent="Menu"]
 layout_mode = 3
 anchors_preset = 3
@@ -662,6 +649,7 @@ script = ExtResource("10")
 [connection signal="pressed" from="Menu/MainMenu/Content/SelectModuleButton" to="Menu" method="_on_SelectModuleButton_pressed"]
 [connection signal="pressed" from="Menu/MainMenu/Content/OptionsButton" to="Menu" method="_on_OptionsButton_pressed"]
 [connection signal="pressed" from="Menu/MainMenu/Content/AboutButton" to="Menu" method="_on_AboutButton_pressed"]
+[connection signal="pressed" from="Menu/MainMenu/Content/ExitModuleButton" to="Menu" method="_on_exit_module_button_pressed"]
 [connection signal="pressed" from="Menu/AboutScreen/VBoxContainer/CloseButton" to="Menu" method="_on_About_CloseButton_pressed"]
 [connection signal="toggled" from="Menu/OptionsScreen/VBoxContainer/MouseDragToggle" to="Menu" method="_on_MouseDragToggle_toggled"]
 [connection signal="toggled" from="Menu/OptionsScreen/VBoxContainer/ObjectTooltipsToggle" to="Menu" method="_on_ObjectTooltipsToggle_toggled"]
@@ -672,4 +660,3 @@ script = ExtResource("10")
 [connection signal="pressed" from="Menu/FinalReport/VBoxContainer/HBoxContainer/ContinueButton" to="Menu" method="_on_FinalReport_ContinueButton_pressed"]
 [connection signal="pressed" from="Menu/LogButton" to="Menu" method="_on_LogButton_pressed"]
 [connection signal="tab_changed" from="Menu/LogButton/LogMenu" to="Menu" method="SetLogNotificationCounts"]
-[connection signal="pressed" from="Menu/LogButton/LogMenu/Exit Module/Node2D/ExitModuleButton" to="Menu/LogButton/LogMenu/Exit Module/Node2D" method="_on_exit_module_button_pressed"]

--- a/project/source/Main.tscn
+++ b/project/source/Main.tscn
@@ -79,7 +79,7 @@ offset_right = 640.0
 offset_bottom = 360.0
 texture = ExtResource("3")
 
-[node name="MenuPages" type="Control" parent="Menu"]
+[node name="MenuScreens" type="Control" parent="Menu"]
 layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0
@@ -87,7 +87,7 @@ anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
 
-[node name="PauseMenu" type="Control" parent="Menu/MenuPages"]
+[node name="PauseMenu" type="Control" parent="Menu/MenuScreens"]
 layout_mode = 1
 anchors_preset = 8
 anchor_left = 0.5
@@ -97,7 +97,7 @@ anchor_bottom = 0.5
 grow_horizontal = 2
 grow_vertical = 2
 
-[node name="Content" type="VBoxContainer" parent="Menu/MenuPages/PauseMenu"]
+[node name="Content" type="VBoxContainer" parent="Menu/MenuScreens/PauseMenu"]
 layout_mode = 0
 anchor_left = 0.5
 anchor_top = 0.5
@@ -108,7 +108,7 @@ offset_top = -96.5
 offset_right = 200.0
 offset_bottom = 96.5
 
-[node name="Logo" type="TextureRect" parent="Menu/MenuPages/PauseMenu/Content"]
+[node name="Logo" type="TextureRect" parent="Menu/MenuScreens/PauseMenu/Content"]
 visible = false
 custom_minimum_size = Vector2(400, 100)
 layout_mode = 2
@@ -116,36 +116,36 @@ texture = ExtResource("11")
 expand_mode = 1
 stretch_mode = 5
 
-[node name="SelectModuleButton" type="Button" parent="Menu/MenuPages/PauseMenu/Content"]
+[node name="SelectModuleButton" type="Button" parent="Menu/MenuScreens/PauseMenu/Content"]
 layout_mode = 2
 theme_override_fonts/font = ExtResource("12")
 text = "Select Module"
 
-[node name="RestartModuleButton" type="Button" parent="Menu/MenuPages/PauseMenu/Content"]
+[node name="RestartModuleButton" type="Button" parent="Menu/MenuScreens/PauseMenu/Content"]
 visible = false
 layout_mode = 2
 text = "Restart Module"
 
-[node name="ExitModuleButton" type="Button" parent="Menu/MenuPages/PauseMenu/Content"]
+[node name="ExitModuleButton" type="Button" parent="Menu/MenuScreens/PauseMenu/Content"]
 visible = false
 layout_mode = 2
 text = "Return to Main Menu"
 
-[node name="OptionsButton" type="Button" parent="Menu/MenuPages/PauseMenu/Content"]
+[node name="OptionsButton" type="Button" parent="Menu/MenuScreens/PauseMenu/Content"]
 layout_mode = 2
 theme_override_fonts/font = ExtResource("12")
 text = "Options"
 
-[node name="AboutButton" type="Button" parent="Menu/MenuPages/PauseMenu/Content"]
+[node name="AboutButton" type="Button" parent="Menu/MenuScreens/PauseMenu/Content"]
 layout_mode = 2
 theme_override_fonts/font = ExtResource("12")
 text = "About"
 
-[node name="QuitButton" type="Button" parent="Menu/MenuPages/PauseMenu/Content"]
+[node name="QuitButton" type="Button" parent="Menu/MenuScreens/PauseMenu/Content"]
 layout_mode = 2
 text = "Quit"
 
-[node name="AboutScreen" type="PanelContainer" parent="Menu/MenuPages"]
+[node name="AboutScreen" type="PanelContainer" parent="Menu/MenuScreens"]
 visible = false
 layout_mode = 1
 anchors_preset = 8
@@ -158,16 +158,16 @@ offset_top = -235.0
 offset_right = 400.0
 offset_bottom = 240.0
 
-[node name="VBoxContainer" type="VBoxContainer" parent="Menu/MenuPages/AboutScreen"]
+[node name="VBoxContainer" type="VBoxContainer" parent="Menu/MenuScreens/AboutScreen"]
 layout_mode = 2
 
-[node name="Label" type="Label" parent="Menu/MenuPages/AboutScreen/VBoxContainer"]
+[node name="Label" type="Label" parent="Menu/MenuScreens/AboutScreen/VBoxContainer"]
 custom_minimum_size = Vector2(0, 20)
 layout_mode = 2
 text = "About"
 horizontal_alignment = 1
 
-[node name="Text" type="RichTextLabel" parent="Menu/MenuPages/AboutScreen/VBoxContainer"]
+[node name="Text" type="RichTextLabel" parent="Menu/MenuScreens/AboutScreen/VBoxContainer"]
 custom_minimum_size = Vector2(600, 400)
 layout_mode = 2
 bbcode_enabled = true
@@ -413,11 +413,11 @@ The following tools, projects, and assets are used under their respective licens
 									   See the License for the specific language governing permissions and
 									   limitations under the License."
 
-[node name="CloseButton" type="Button" parent="Menu/MenuPages/AboutScreen/VBoxContainer"]
+[node name="CloseButton" type="Button" parent="Menu/MenuScreens/AboutScreen/VBoxContainer"]
 layout_mode = 2
 text = "Close"
 
-[node name="OptionsScreen" type="PanelContainer" parent="Menu/MenuPages"]
+[node name="OptionsScreen" type="PanelContainer" parent="Menu/MenuScreens"]
 visible = false
 layout_mode = 1
 anchors_preset = 8
@@ -430,41 +430,41 @@ offset_top = -84.5
 offset_right = 150.0
 offset_bottom = 84.5
 
-[node name="VBoxContainer" type="VBoxContainer" parent="Menu/MenuPages/OptionsScreen"]
+[node name="VBoxContainer" type="VBoxContainer" parent="Menu/MenuScreens/OptionsScreen"]
 layout_mode = 2
 
-[node name="Label" type="Label" parent="Menu/MenuPages/OptionsScreen/VBoxContainer"]
+[node name="Label" type="Label" parent="Menu/MenuScreens/OptionsScreen/VBoxContainer"]
 custom_minimum_size = Vector2(0, 20)
 layout_mode = 2
 text = "Options"
 horizontal_alignment = 1
 
-[node name="MouseDragToggle" type="CheckButton" parent="Menu/MenuPages/OptionsScreen/VBoxContainer"]
+[node name="MouseDragToggle" type="CheckButton" parent="Menu/MenuScreens/OptionsScreen/VBoxContainer"]
 visible = false
 layout_mode = 2
 text = "Enable Dragging Camera3D with Mouse"
 
-[node name="ObjectTooltipsToggle" type="CheckButton" parent="Menu/MenuPages/OptionsScreen/VBoxContainer"]
+[node name="ObjectTooltipsToggle" type="CheckButton" parent="Menu/MenuScreens/OptionsScreen/VBoxContainer"]
 layout_mode = 2
 text = "Object Tooltips"
 
-[node name="PopupDuration" type="HSplitContainer" parent="Menu/MenuPages/OptionsScreen/VBoxContainer"]
+[node name="PopupDuration" type="HSplitContainer" parent="Menu/MenuScreens/OptionsScreen/VBoxContainer"]
 layout_mode = 2
 
-[node name="PopupDurationTitle" type="Label" parent="Menu/MenuPages/OptionsScreen/VBoxContainer/PopupDuration"]
+[node name="PopupDurationTitle" type="Label" parent="Menu/MenuScreens/OptionsScreen/VBoxContainer/PopupDuration"]
 layout_mode = 2
 text = "Popup Duration"
 
-[node name="PopupTimeout" type="SpinBox" parent="Menu/MenuPages/OptionsScreen/VBoxContainer/PopupDuration"]
+[node name="PopupTimeout" type="SpinBox" parent="Menu/MenuScreens/OptionsScreen/VBoxContainer/PopupDuration"]
 layout_mode = 2
 max_value = 5.0
 step = 0.5
 
-[node name="CloseButton" type="Button" parent="Menu/MenuPages/OptionsScreen/VBoxContainer"]
+[node name="CloseButton" type="Button" parent="Menu/MenuScreens/OptionsScreen/VBoxContainer"]
 layout_mode = 2
 text = "Close"
 
-[node name="ModuleSelect" type="PanelContainer" parent="Menu/MenuPages"]
+[node name="ModuleSelect" type="PanelContainer" parent="Menu/MenuScreens"]
 visible = false
 layout_mode = 1
 anchors_preset = 8
@@ -479,29 +479,29 @@ offset_bottom = 10.0
 grow_horizontal = 2
 grow_vertical = 2
 
-[node name="VBoxContainer" type="VBoxContainer" parent="Menu/MenuPages/ModuleSelect"]
+[node name="VBoxContainer" type="VBoxContainer" parent="Menu/MenuScreens/ModuleSelect"]
 layout_mode = 2
 
-[node name="Label" type="Label" parent="Menu/MenuPages/ModuleSelect/VBoxContainer"]
+[node name="Label" type="Label" parent="Menu/MenuScreens/ModuleSelect/VBoxContainer"]
 layout_mode = 2
 text = "Modules"
 horizontal_alignment = 1
 
-[node name="ScrollContainer" type="ScrollContainer" parent="Menu/MenuPages/ModuleSelect/VBoxContainer"]
+[node name="ScrollContainer" type="ScrollContainer" parent="Menu/MenuScreens/ModuleSelect/VBoxContainer"]
 custom_minimum_size = Vector2(0, 200)
 layout_mode = 2
 horizontal_scroll_mode = 0
 
-[node name="Modules" type="GridContainer" parent="Menu/MenuPages/ModuleSelect/VBoxContainer/ScrollContainer"]
+[node name="Modules" type="GridContainer" parent="Menu/MenuScreens/ModuleSelect/VBoxContainer/ScrollContainer"]
 unique_name_in_owner = true
 layout_mode = 2
 columns = 3
 
-[node name="Blank" type="Control" parent="Menu/MenuPages/ModuleSelect/VBoxContainer"]
+[node name="Blank" type="Control" parent="Menu/MenuScreens/ModuleSelect/VBoxContainer"]
 custom_minimum_size = Vector2(0, 20)
 layout_mode = 2
 
-[node name="CloseButton" type="Button" parent="Menu/MenuPages/ModuleSelect/VBoxContainer"]
+[node name="CloseButton" type="Button" parent="Menu/MenuScreens/ModuleSelect/VBoxContainer"]
 layout_mode = 2
 text = "Close"
 
@@ -698,18 +698,18 @@ editor_only = false
 position = Vector2(-2, -2)
 script = ExtResource("10")
 
-[connection signal="pressed" from="Menu/MenuPages/PauseMenu/Content/SelectModuleButton" to="Menu" method="_on_SelectModuleButton_pressed"]
-[connection signal="pressed" from="Menu/MenuPages/PauseMenu/Content/RestartModuleButton" to="Menu" method="_on_restart_module_button_pressed"]
-[connection signal="pressed" from="Menu/MenuPages/PauseMenu/Content/ExitModuleButton" to="Menu" method="_on_exit_module_button_pressed"]
-[connection signal="pressed" from="Menu/MenuPages/PauseMenu/Content/OptionsButton" to="Menu" method="_on_OptionsButton_pressed"]
-[connection signal="pressed" from="Menu/MenuPages/PauseMenu/Content/AboutButton" to="Menu" method="_on_AboutButton_pressed"]
-[connection signal="pressed" from="Menu/MenuPages/PauseMenu/Content/QuitButton" to="Menu" method="_on_quit_button_pressed"]
-[connection signal="pressed" from="Menu/MenuPages/AboutScreen/VBoxContainer/CloseButton" to="Menu" method="_on_About_CloseButton_pressed"]
-[connection signal="toggled" from="Menu/MenuPages/OptionsScreen/VBoxContainer/MouseDragToggle" to="Menu" method="_on_MouseDragToggle_toggled"]
-[connection signal="toggled" from="Menu/MenuPages/OptionsScreen/VBoxContainer/ObjectTooltipsToggle" to="Menu" method="_on_ObjectTooltipsToggle_toggled"]
-[connection signal="value_changed" from="Menu/MenuPages/OptionsScreen/VBoxContainer/PopupDuration/PopupTimeout" to="Menu" method="_on_PopupTimeout_value_changed"]
-[connection signal="pressed" from="Menu/MenuPages/OptionsScreen/VBoxContainer/CloseButton" to="Menu" method="_on_CloseButton_pressed"]
-[connection signal="pressed" from="Menu/MenuPages/ModuleSelect/VBoxContainer/CloseButton" to="Menu" method="_on_module_select_close_button_pressed"]
+[connection signal="pressed" from="Menu/MenuScreens/PauseMenu/Content/SelectModuleButton" to="Menu" method="_on_SelectModuleButton_pressed"]
+[connection signal="pressed" from="Menu/MenuScreens/PauseMenu/Content/RestartModuleButton" to="Menu" method="_on_restart_module_button_pressed"]
+[connection signal="pressed" from="Menu/MenuScreens/PauseMenu/Content/ExitModuleButton" to="Menu" method="_on_exit_module_button_pressed"]
+[connection signal="pressed" from="Menu/MenuScreens/PauseMenu/Content/OptionsButton" to="Menu" method="_on_OptionsButton_pressed"]
+[connection signal="pressed" from="Menu/MenuScreens/PauseMenu/Content/AboutButton" to="Menu" method="_on_AboutButton_pressed"]
+[connection signal="pressed" from="Menu/MenuScreens/PauseMenu/Content/QuitButton" to="Menu" method="_on_quit_button_pressed"]
+[connection signal="pressed" from="Menu/MenuScreens/AboutScreen/VBoxContainer/CloseButton" to="Menu" method="_on_About_CloseButton_pressed"]
+[connection signal="toggled" from="Menu/MenuScreens/OptionsScreen/VBoxContainer/MouseDragToggle" to="Menu" method="_on_MouseDragToggle_toggled"]
+[connection signal="toggled" from="Menu/MenuScreens/OptionsScreen/VBoxContainer/ObjectTooltipsToggle" to="Menu" method="_on_ObjectTooltipsToggle_toggled"]
+[connection signal="value_changed" from="Menu/MenuScreens/OptionsScreen/VBoxContainer/PopupDuration/PopupTimeout" to="Menu" method="_on_PopupTimeout_value_changed"]
+[connection signal="pressed" from="Menu/MenuScreens/OptionsScreen/VBoxContainer/CloseButton" to="Menu" method="_on_CloseButton_pressed"]
+[connection signal="pressed" from="Menu/MenuScreens/ModuleSelect/VBoxContainer/CloseButton" to="Menu" method="_on_module_select_close_button_pressed"]
 [connection signal="pressed" from="Menu/FinalReport/VBoxContainer/HBoxContainer/MainMenuButton" to="Menu" method="_on_FinalReport_MainMenuButton_pressed"]
 [connection signal="pressed" from="Menu/FinalReport/VBoxContainer/HBoxContainer/RestartModuleButton" to="Menu" method="_on_FinalReport_RestartModuleButton_pressed"]
 [connection signal="pressed" from="Menu/FinalReport/VBoxContainer/HBoxContainer/ContinueButton" to="Menu" method="_on_FinalReport_ContinueButton_pressed"]

--- a/project/source/Main.tscn
+++ b/project/source/Main.tscn
@@ -135,6 +135,14 @@ text = "About"
 layout_mode = 2
 text = "Return to Main Menu"
 
+[node name="RestartModuleButton" type="Button" parent="Menu/MenuPages/PauseMenu/Content"]
+layout_mode = 2
+text = "Restart Module"
+
+[node name="QuitButton" type="Button" parent="Menu/MenuPages/PauseMenu/Content"]
+layout_mode = 2
+text = "Quit"
+
 [node name="ModuleSelect" type="GridContainer" parent="Menu/MenuPages"]
 layout_mode = 1
 anchors_preset = 13
@@ -661,6 +669,8 @@ script = ExtResource("10")
 [connection signal="pressed" from="Menu/MenuPages/PauseMenu/Content/OptionsButton" to="Menu" method="_on_OptionsButton_pressed"]
 [connection signal="pressed" from="Menu/MenuPages/PauseMenu/Content/AboutButton" to="Menu" method="_on_AboutButton_pressed"]
 [connection signal="pressed" from="Menu/MenuPages/PauseMenu/Content/ExitModuleButton" to="Menu" method="_on_exit_module_button_pressed"]
+[connection signal="pressed" from="Menu/MenuPages/PauseMenu/Content/RestartModuleButton" to="Menu" method="_on_restart_module_button_pressed"]
+[connection signal="pressed" from="Menu/MenuPages/PauseMenu/Content/QuitButton" to="Menu" method="_on_quit_button_pressed"]
 [connection signal="pressed" from="Menu/MenuPages/AboutScreen/VBoxContainer/CloseButton" to="Menu" method="_on_About_CloseButton_pressed"]
 [connection signal="toggled" from="Menu/MenuPages/OptionsScreen/VBoxContainer/MouseDragToggle" to="Menu" method="_on_MouseDragToggle_toggled"]
 [connection signal="toggled" from="Menu/MenuPages/OptionsScreen/VBoxContainer/ObjectTooltipsToggle" to="Menu" method="_on_ObjectTooltipsToggle_toggled"]

--- a/project/source/Main.tscn
+++ b/project/source/Main.tscn
@@ -114,12 +114,20 @@ custom_minimum_size = Vector2(400, 100)
 layout_mode = 2
 texture = ExtResource("11")
 expand_mode = 1
-stretch_mode = 7
+stretch_mode = 5
 
 [node name="SelectModuleButton" type="Button" parent="Menu/MenuPages/PauseMenu/Content"]
 layout_mode = 2
 theme_override_fonts/font = ExtResource("12")
 text = "Select Module"
+
+[node name="RestartModuleButton" type="Button" parent="Menu/MenuPages/PauseMenu/Content"]
+layout_mode = 2
+text = "Restart Module"
+
+[node name="ExitModuleButton" type="Button" parent="Menu/MenuPages/PauseMenu/Content"]
+layout_mode = 2
+text = "Return to Main Menu"
 
 [node name="OptionsButton" type="Button" parent="Menu/MenuPages/PauseMenu/Content"]
 layout_mode = 2
@@ -130,14 +138,6 @@ text = "Options"
 layout_mode = 2
 theme_override_fonts/font = ExtResource("12")
 text = "About"
-
-[node name="ExitModuleButton" type="Button" parent="Menu/MenuPages/PauseMenu/Content"]
-layout_mode = 2
-text = "Return to Main Menu"
-
-[node name="RestartModuleButton" type="Button" parent="Menu/MenuPages/PauseMenu/Content"]
-layout_mode = 2
-text = "Restart Module"
 
 [node name="QuitButton" type="Button" parent="Menu/MenuPages/PauseMenu/Content"]
 layout_mode = 2
@@ -666,10 +666,10 @@ position = Vector2(-2, -2)
 script = ExtResource("10")
 
 [connection signal="pressed" from="Menu/MenuPages/PauseMenu/Content/SelectModuleButton" to="Menu" method="_on_SelectModuleButton_pressed"]
+[connection signal="pressed" from="Menu/MenuPages/PauseMenu/Content/RestartModuleButton" to="Menu" method="_on_restart_module_button_pressed"]
+[connection signal="pressed" from="Menu/MenuPages/PauseMenu/Content/ExitModuleButton" to="Menu" method="_on_exit_module_button_pressed"]
 [connection signal="pressed" from="Menu/MenuPages/PauseMenu/Content/OptionsButton" to="Menu" method="_on_OptionsButton_pressed"]
 [connection signal="pressed" from="Menu/MenuPages/PauseMenu/Content/AboutButton" to="Menu" method="_on_AboutButton_pressed"]
-[connection signal="pressed" from="Menu/MenuPages/PauseMenu/Content/ExitModuleButton" to="Menu" method="_on_exit_module_button_pressed"]
-[connection signal="pressed" from="Menu/MenuPages/PauseMenu/Content/RestartModuleButton" to="Menu" method="_on_restart_module_button_pressed"]
 [connection signal="pressed" from="Menu/MenuPages/PauseMenu/Content/QuitButton" to="Menu" method="_on_quit_button_pressed"]
 [connection signal="pressed" from="Menu/MenuPages/AboutScreen/VBoxContainer/CloseButton" to="Menu" method="_on_About_CloseButton_pressed"]
 [connection signal="toggled" from="Menu/MenuPages/OptionsScreen/VBoxContainer/MouseDragToggle" to="Menu" method="_on_MouseDragToggle_toggled"]

--- a/project/source/Main.tscn
+++ b/project/source/Main.tscn
@@ -87,7 +87,7 @@ anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
 
-[node name="MainMenu" type="Control" parent="Menu/MenuPages"]
+[node name="PauseMenu" type="Control" parent="Menu/MenuPages"]
 layout_mode = 1
 anchors_preset = 8
 anchor_left = 0.5
@@ -97,7 +97,7 @@ anchor_bottom = 0.5
 grow_horizontal = 2
 grow_vertical = 2
 
-[node name="Content" type="VBoxContainer" parent="Menu/MenuPages/MainMenu"]
+[node name="Content" type="VBoxContainer" parent="Menu/MenuPages/PauseMenu"]
 layout_mode = 0
 anchor_left = 0.5
 anchor_top = 0.5
@@ -108,7 +108,7 @@ offset_top = -96.5
 offset_right = 200.0
 offset_bottom = 96.5
 
-[node name="Logo" type="TextureRect" parent="Menu/MenuPages/MainMenu/Content"]
+[node name="Logo" type="TextureRect" parent="Menu/MenuPages/PauseMenu/Content"]
 visible = false
 custom_minimum_size = Vector2(400, 100)
 layout_mode = 2
@@ -116,22 +116,22 @@ texture = ExtResource("11")
 expand_mode = 1
 stretch_mode = 7
 
-[node name="SelectModuleButton" type="Button" parent="Menu/MenuPages/MainMenu/Content"]
+[node name="SelectModuleButton" type="Button" parent="Menu/MenuPages/PauseMenu/Content"]
 layout_mode = 2
 theme_override_fonts/font = ExtResource("12")
 text = "Select Module"
 
-[node name="OptionsButton" type="Button" parent="Menu/MenuPages/MainMenu/Content"]
+[node name="OptionsButton" type="Button" parent="Menu/MenuPages/PauseMenu/Content"]
 layout_mode = 2
 theme_override_fonts/font = ExtResource("12")
 text = "Options"
 
-[node name="AboutButton" type="Button" parent="Menu/MenuPages/MainMenu/Content"]
+[node name="AboutButton" type="Button" parent="Menu/MenuPages/PauseMenu/Content"]
 layout_mode = 2
 theme_override_fonts/font = ExtResource("12")
 text = "About"
 
-[node name="ExitModuleButton" type="Button" parent="Menu/MenuPages/MainMenu/Content"]
+[node name="ExitModuleButton" type="Button" parent="Menu/MenuPages/PauseMenu/Content"]
 layout_mode = 2
 text = "Return to Main Menu"
 
@@ -657,10 +657,10 @@ editor_only = false
 position = Vector2(-2, -2)
 script = ExtResource("10")
 
-[connection signal="pressed" from="Menu/MenuPages/MainMenu/Content/SelectModuleButton" to="Menu" method="_on_SelectModuleButton_pressed"]
-[connection signal="pressed" from="Menu/MenuPages/MainMenu/Content/OptionsButton" to="Menu" method="_on_OptionsButton_pressed"]
-[connection signal="pressed" from="Menu/MenuPages/MainMenu/Content/AboutButton" to="Menu" method="_on_AboutButton_pressed"]
-[connection signal="pressed" from="Menu/MenuPages/MainMenu/Content/ExitModuleButton" to="Menu" method="_on_exit_module_button_pressed"]
+[connection signal="pressed" from="Menu/MenuPages/PauseMenu/Content/SelectModuleButton" to="Menu" method="_on_SelectModuleButton_pressed"]
+[connection signal="pressed" from="Menu/MenuPages/PauseMenu/Content/OptionsButton" to="Menu" method="_on_OptionsButton_pressed"]
+[connection signal="pressed" from="Menu/MenuPages/PauseMenu/Content/AboutButton" to="Menu" method="_on_AboutButton_pressed"]
+[connection signal="pressed" from="Menu/MenuPages/PauseMenu/Content/ExitModuleButton" to="Menu" method="_on_exit_module_button_pressed"]
 [connection signal="pressed" from="Menu/MenuPages/AboutScreen/VBoxContainer/CloseButton" to="Menu" method="_on_About_CloseButton_pressed"]
 [connection signal="toggled" from="Menu/MenuPages/OptionsScreen/VBoxContainer/MouseDragToggle" to="Menu" method="_on_MouseDragToggle_toggled"]
 [connection signal="toggled" from="Menu/MenuPages/OptionsScreen/VBoxContainer/ObjectTooltipsToggle" to="Menu" method="_on_ObjectTooltipsToggle_toggled"]

--- a/project/source/Scenes/Modules/exit_module_button.gd
+++ b/project/source/Scenes/Modules/exit_module_button.gd
@@ -1,4 +1,0 @@
-extends Node2D
-
-func _on_exit_module_button_pressed() -> void:
-	get_tree().change_scene_to_file("res://Main.tscn") 

--- a/project/source/Scripts/UI/Menu.gd
+++ b/project/source/Scripts/UI/Menu.gd
@@ -66,21 +66,21 @@ func _process(delta: float) -> void:
 func _unhandled_key_input(e: InputEvent) -> void:
 	if e.is_action_pressed(&"ToggleMenu"):
 		# A page other than the main pause menu is being shown; return to the pause menu.
-		if $MenuPages.visible and not $MenuPages/PauseMenu.visible:
-			_switch_to_menu_page($MenuPages/PauseMenu)
+		if $MenuScreens.visible and not $MenuScreens/PauseMenu.visible:
+			_switch_to_menu_screen($MenuScreens/PauseMenu)
 		# Toggle the pause menu only if we're in a module.
 		elif $"..".current_module_scene != null:
-			$MenuPages.visible = not $MenuPages.visible
+			$MenuScreens.visible = not $MenuScreens.visible
 
 func _load_module(module: ModuleData) -> void:
 	get_parent().set_scene(module.scene)
 
-	_switch_to_menu_page($MenuPages/PauseMenu)
+	_switch_to_menu_screen($MenuScreens/PauseMenu)
 	$Background.hide()
-	$MenuPages/PauseMenu/Content/Logo.show()
-	$MenuPages/PauseMenu/Content/ExitModuleButton.show()
-	$MenuPages/PauseMenu/Content/RestartModuleButton.show()
-	$MenuPages.hide()
+	$MenuScreens/PauseMenu/Content/Logo.show()
+	$MenuScreens/PauseMenu/Content/ExitModuleButton.show()
+	$MenuScreens/PauseMenu/Content/RestartModuleButton.show()
+	$MenuScreens.hide()
 
 	current_module = module
 	$LogButton.show()
@@ -88,10 +88,10 @@ func _load_module(module: ModuleData) -> void:
 	$LogButton/LogMenu/Instructions.show()
 
 func _on_SelectModuleButton_pressed() -> void:
-	_switch_to_menu_page($MenuPages/ModuleSelect)
+	_switch_to_menu_screen($MenuScreens/ModuleSelect)
 
 func _on_AboutButton_pressed() -> void:
-	_switch_to_menu_page($MenuPages/AboutScreen)
+	_switch_to_menu_screen($MenuScreens/AboutScreen)
 
 func _on_LogButton_pressed() -> void:
 	$LogButton/LogMenu.visible = ! $LogButton/LogMenu.visible
@@ -205,19 +205,19 @@ func _on_FinalReport_RestartModuleButton_pressed() -> void:
 	$FinalReport.hide()
 
 func _on_FinalReport_ContinueButton_pressed() -> void:
-	_switch_to_menu_page($MenuPages/PauseMenu)
+	_switch_to_menu_screen($MenuScreens/PauseMenu)
 
 func _on_About_CloseButton_pressed() -> void:
-	_switch_to_menu_page($MenuPages/PauseMenu)
+	_switch_to_menu_screen($MenuScreens/PauseMenu)
 
 func _on_OptionsButton_pressed() -> void:
-	_switch_to_menu_page($MenuPages/OptionsScreen)
-	$MenuPages/OptionsScreen/VBoxContainer/MouseDragToggle.button_pressed = GameSettings.mouse_camera_drag
-	$MenuPages/OptionsScreen/VBoxContainer/ObjectTooltipsToggle.button_pressed = GameSettings.object_tooltips
-	$MenuPages/OptionsScreen/VBoxContainer/PopupDuration/PopupTimeout.value = GameSettings.popup_timeout
+	_switch_to_menu_screen($MenuScreens/OptionsScreen)
+	$MenuScreens/OptionsScreen/VBoxContainer/MouseDragToggle.button_pressed = GameSettings.mouse_camera_drag
+	$MenuScreens/OptionsScreen/VBoxContainer/ObjectTooltipsToggle.button_pressed = GameSettings.object_tooltips
+	$MenuScreens/OptionsScreen/VBoxContainer/PopupDuration/PopupTimeout.value = GameSettings.popup_timeout
 
 func _on_CloseButton_pressed() -> void:
-	_switch_to_menu_page($MenuPages/PauseMenu)
+	_switch_to_menu_screen($MenuScreens/PauseMenu)
 
 func _on_MouseDragToggle_toggled(button_pressed: bool) -> void:
 	GameSettings.mouse_camera_drag = button_pressed
@@ -237,10 +237,10 @@ func _on_exit_module_button_pressed() -> void:
 func _switch_to_main_menu() -> void:
 	$"..".unload_current_module()
 
-	_switch_to_menu_page($MenuPages/PauseMenu)
-	$MenuPages/PauseMenu/Content/Logo.hide()
-	$MenuPages/PauseMenu/Content/ExitModuleButton.hide()
-	$MenuPages/PauseMenu/Content/RestartModuleButton.hide()
+	_switch_to_menu_screen($MenuScreens/PauseMenu)
+	$MenuScreens/PauseMenu/Content/Logo.hide()
+	$MenuScreens/PauseMenu/Content/ExitModuleButton.hide()
+	$MenuScreens/PauseMenu/Content/RestartModuleButton.hide()
 	$Background.show()
 
 	$LogButton.hide() #until we load a module
@@ -248,11 +248,11 @@ func _switch_to_main_menu() -> void:
 	$FinalReport.hide()
 	$LabLogPopup.hide()
 
-# Only one of the UI elements in `$MenuPages` can be shown at once. These are
+# Only one of the UI elements in `$MenuScreens` can be shown at once. These are
 # the UI elements that show up in the middle of the screen, and them overlapping is problematic.
-func _switch_to_menu_page(menu: Control) -> void:
-	if not $MenuPages.get_children().has(menu): return
-	for m in $MenuPages.get_children():
+func _switch_to_menu_screen(menu: Control) -> void:
+	if not $MenuScreens.get_children().has(menu): return
+	for m in $MenuScreens.get_children():
 		m.hide()
 	menu.show()
 
@@ -263,4 +263,4 @@ func _on_restart_module_button_pressed() -> void:
 	_load_module(current_module)
 
 func _on_module_select_close_button_pressed() -> void:
-	_switch_to_menu_page($MenuPages/PauseMenu)
+	_switch_to_menu_screen($MenuScreens/PauseMenu)

--- a/project/source/Scripts/UI/Menu.gd
+++ b/project/source/Scripts/UI/Menu.gd
@@ -243,3 +243,6 @@ func _on_PopupTimeout_value_changed(value: float) -> void:
 
 static func log_category_to_string(category: LogMessage.Category) -> String:
 	return LogMessage.Category.keys()[category].to_lower()
+
+func _on_exit_module_button_pressed() -> void:
+	$"..".return_to_menu()

--- a/project/source/Scripts/UI/Menu.gd
+++ b/project/source/Scripts/UI/Menu.gd
@@ -79,6 +79,7 @@ func _load_module(module: ModuleData) -> void:
 	$Background.hide()
 	$MenuPages/PauseMenu/Content/Logo.show()
 	$MenuPages/PauseMenu/Content/ExitModuleButton.show()
+	$MenuPages/PauseMenu/Content/RestartModuleButton.show()
 	$MenuPages.hide()
 
 	current_module = module
@@ -239,6 +240,7 @@ func _switch_to_main_menu() -> void:
 	_switch_to_menu_page($MenuPages/PauseMenu)
 	$MenuPages/PauseMenu/Content/Logo.hide()
 	$MenuPages/PauseMenu/Content/ExitModuleButton.hide()
+	$MenuPages/PauseMenu/Content/RestartModuleButton.hide()
 	$Background.show()
 
 	$LogButton.hide() #until we load a module
@@ -253,3 +255,9 @@ func _switch_to_menu_page(menu: Control) -> void:
 	for m in $MenuPages.get_children():
 		m.hide()
 	menu.show()
+
+func _on_quit_button_pressed() -> void:
+	get_tree().quit()
+
+func _on_restart_module_button_pressed() -> void:
+	_load_module(current_module)

--- a/project/source/Scripts/UI/Menu.gd
+++ b/project/source/Scripts/UI/Menu.gd
@@ -43,7 +43,7 @@ func _ready() -> void:
 			var new_button := module_button.instantiate()
 			new_button.set_data(module_data)
 			new_button.connect("pressed", Callable(self, &"_load_module").bind(module_data))
-			$MenuPages/ModuleSelect.add_child(new_button)
+			$%Modules.add_child(new_button)
 
 	#connect the log signals
 	LabLog.connect("new_message", Callable(self, "_on_New_Log_Message"))
@@ -261,3 +261,6 @@ func _on_quit_button_pressed() -> void:
 
 func _on_restart_module_button_pressed() -> void:
 	_load_module(current_module)
+
+func _on_module_select_close_button_pressed() -> void:
+	_switch_to_menu_page($MenuPages/PauseMenu)

--- a/project/source/Scripts/UI/Menu.gd
+++ b/project/source/Scripts/UI/Menu.gd
@@ -43,7 +43,7 @@ func _ready() -> void:
 			var new_button := module_button.instantiate()
 			new_button.set_data(module_data)
 			new_button.connect("pressed", Callable(self, &"_load_module").bind(module_data))
-			$ModuleSelect.add_child(new_button)
+			$MenuPages/ModuleSelect.add_child(new_button)
 
 	#connect the log signals
 	LabLog.connect("new_message", Callable(self, "_on_New_Log_Message"))
@@ -64,17 +64,22 @@ func _process(delta: float) -> void:
 			logs.remove_at(0)
 
 func _unhandled_key_input(e: InputEvent) -> void:
-	# Only toggle the menu when we're in a module.
-	if e.is_action_pressed(&"ToggleMenu") and $"..".current_module_scene != null:
-		$MenuPages.visible = not $MenuPages.visible
+	if e.is_action_pressed(&"ToggleMenu"):
+		# A page other than the main pause menu is being shown; return to the pause menu.
+		if $MenuPages.visible and not $MenuPages/MainMenu.visible:
+			_switch_to_menu_page($MenuPages/MainMenu)
+		# Toggle the pause menu only if we're in a module.
+		elif $"..".current_module_scene != null:
+			$MenuPages.visible = not $MenuPages.visible
 
 func _load_module(module: ModuleData) -> void:
 	get_parent().set_scene(module.scene)
 
 	_switch_to_menu_page($MenuPages/MainMenu)
-	$MenuPages/MainMenu/Background.hide()
+	$Background.hide()
 	$MenuPages/MainMenu/Content/Logo.show()
 	$MenuPages/MainMenu/Content/ExitModuleButton.show()
+	$MenuPages.hide()
 
 	current_module = module
 	$LogButton.show()
@@ -202,7 +207,7 @@ func _on_FinalReport_ContinueButton_pressed() -> void:
 	_switch_to_menu_page($MenuPages/MainMenu)
 
 func _on_About_CloseButton_pressed() -> void:
-	$AboutScreen.hide()
+	_switch_to_menu_page($MenuPages/MainMenu)
 
 func _on_OptionsButton_pressed() -> void:
 	_switch_to_menu_page($MenuPages/OptionsScreen)
@@ -211,7 +216,7 @@ func _on_OptionsButton_pressed() -> void:
 	$MenuPages/OptionsScreen/VBoxContainer/PopupDuration/PopupTimeout.value = GameSettings.popup_timeout
 
 func _on_CloseButton_pressed() -> void:
-	$OptionsScreen.hide()
+	_switch_to_menu_page($MenuPages/MainMenu)
 
 func _on_MouseDragToggle_toggled(button_pressed: bool) -> void:
 	GameSettings.mouse_camera_drag = button_pressed
@@ -233,8 +238,8 @@ func _switch_to_main_menu() -> void:
 
 	_switch_to_menu_page($MenuPages/MainMenu)
 	$MenuPages/MainMenu/Content/Logo.hide()
-	$MenuPages/MainMenu/Content/ExitModuleButton.show()
-	$MenuPages/MainMenu/Background.show()
+	$MenuPages/MainMenu/Content/ExitModuleButton.hide()
+	$Background.show()
 
 	$LogButton.hide() #until we load a module
 	$LogButton/LogMenu.hide()
@@ -244,7 +249,7 @@ func _switch_to_main_menu() -> void:
 # Only one of the UI elements in `$MenuPages` can be shown at once. These are
 # the UI elements that show up in the middle of the screen, and them overlapping is problematic.
 func _switch_to_menu_page(menu: Control) -> void:
-	if not $MenuPages.contains(menu): return
+	if not $MenuPages.get_children().has(menu): return
 	for m in $MenuPages.get_children():
 		m.hide()
 	menu.show()

--- a/project/source/Scripts/UI/Menu.gd
+++ b/project/source/Scripts/UI/Menu.gd
@@ -34,55 +34,28 @@ func get_all_files_in_folder(path: String) -> Array[String]:
 
 # Called when the node enters the scene tree for the first time.
 func _ready() -> void:
-	# Due to having one module, the MainMenu should be hidden by default
-	# When more modules are added, it is likely a good idea to show MainMenu by default
-	$MainMenu.show()
-	$ModuleSelect.hide()
-	$OptionsScreen.hide()
-	$AboutScreen.hide()
-	$LogButton.hide() #until we load a module
-	$LogButton/LogMenu.hide()
-	$FinalReport.hide()
-	$LabLogPopup.hide()
-	$MainMenu/Content/Logo.hide()
-	
+	_switch_to_main_menu()
+
 	#Set up the module select buttons
 	for file in get_all_files_in_folder(module_directory):
 		var module_data: ModuleData = load(module_directory + file)
 		if module_data.show:
 			var new_button := module_button.instantiate()
 			new_button.set_data(module_data)
-			new_button.connect("pressed", Callable(self, "module_selected").bind(module_data))
+			new_button.connect("pressed", Callable(self, &"_load_module").bind(module_data))
 			$ModuleSelect.add_child(new_button)
-	
+
 	#connect the log signals
 	LabLog.connect("new_message", Callable(self, "_on_New_Log_Message"))
 	LabLog.connect("ReportShown", Callable(self, "_on_LabLog_Report_Shown"))
 	LabLog.connect("logs_cleared", Callable(self, "_on_Logs_Cleared"))
-	
+
 	set_log_notification_counts()
 	$LogButton/LogMenu.set_tab_icon(1, load("res://Images/Dot-Blue.png"))
 	$LogButton/LogMenu.set_tab_icon(2, load("res://Images/Dot-Yellow.png"))
 	$LogButton/LogMenu.set_tab_icon(3, load("res://Images/Dot-Red.png"))
-	
-	# Since there is one module, it should boot directly into this scene
-	#var module: ModuleData = load(module_directory + "GelElectrophoresis.tres")
-	#module_selected(module)
 
-# Called every frame. 'delta' is the elapsed time since the previous frame.
 func _process(delta: float) -> void:
-	if Input.is_action_just_pressed("ToggleMenu"):
-		if $MainMenu.visible:
-			$MainMenu.hide()
-		else:
-			$MainMenu.show()
-			$ModuleSelect.show()
-			$AboutScreen.hide()
-			$LogButton/LogMenu.hide()
-			$OptionsScreen.hide()
-			$MainMenu/Background.visible = (get_parent().current_module_scene == null)
-			$MainMenu/Content/Logo.visible = not (get_parent().current_module_scene == null)
-			
 	if logs != []:
 		# Need to display log message(s)
 		if !popup_active:
@@ -90,21 +63,29 @@ func _process(delta: float) -> void:
 				show_popup(logs[0])
 			logs.remove_at(0)
 
+func _unhandled_key_input(e: InputEvent) -> void:
+	# Only toggle the menu when we're in a module.
+	if e.is_action_pressed(&"ToggleMenu") and $"..".current_module_scene != null:
+		$MenuPages.visible = not $MenuPages.visible
 
-func module_selected(module: ModuleData) -> void:
+func _load_module(module: ModuleData) -> void:
 	get_parent().set_scene(module.scene)
-	$ModuleSelect.hide()
+
+	_switch_to_menu_page($MenuPages/MainMenu)
+	$MenuPages/MainMenu/Background.hide()
+	$MenuPages/MainMenu/Content/Logo.show()
+	$MenuPages/MainMenu/Content/ExitModuleButton.show()
+
 	current_module = module
 	$LogButton.show()
 	$LogButton/LogMenu/Instructions.text = module.instructions_bb_code
 	$LogButton/LogMenu/Instructions.show()
 
 func _on_SelectModuleButton_pressed() -> void:
-	$MainMenu.hide()
-	$ModuleSelect.show()
+	_switch_to_menu_page($MenuPages/ModuleSelect)
 
 func _on_AboutButton_pressed() -> void:
-	$AboutScreen.show()
+	_switch_to_menu_page($MenuPages/AboutScreen)
 
 func _on_LogButton_pressed() -> void:
 	$LogButton/LogMenu.visible = ! $LogButton/LogMenu.visible
@@ -166,21 +147,21 @@ func set_log_notification_counts(tab: int = -1) -> void:
 		#Do not ever clear error notifications
 		#elif $LogButton/LogMenu.current_tab == 3:
 		#	unread_logs[LogMessage.Category.ERROR] = 0
-	
+
 	if unread_logs[LogMessage.Category.LOG] == 0:
 		$LogButton/LogMenu.set_tab_title(1, "Log")
 		$LogButton/Notifications/Log.hide()
 	else:
 		$LogButton/LogMenu.set_tab_title(1, "Log (" + str(unread_logs[LogMessage.Category.LOG]) + "!)")
 		$LogButton/Notifications/Log.show()
-	
+
 	if unread_logs[LogMessage.Category.WARNING] == 0:
 		$LogButton/LogMenu.set_tab_title(2, "Warnings")
 		$LogButton/Notifications/Warning.hide()
 	else:
 		$LogButton/LogMenu.set_tab_title(2, "Warnings (" + str(unread_logs[LogMessage.Category.WARNING]) + "!)")
 		$LogButton/Notifications/Warning.show()
-	
+
 	if unread_logs[LogMessage.Category.ERROR] == 0:
 		$LogButton/LogMenu.set_tab_title(3, "Errors")
 		$LogButton/Notifications/Error.hide()
@@ -195,14 +176,14 @@ func _on_LabLog_Report_Shown() -> void:
 		logs_text += "[color=yellow]-" + warning.message + "[/color]\n"
 	for error in LabLog.get_logs(LogMessage.Category.ERROR):
 		logs_text += "[color=red]-" + error.message + "[/color]\n"
-	
+
 	if logs_text != "":
 		logs_text = "You weren't perfect though - here's some notes:\n" + logs_text
 		$FinalReport/VBoxContainer/Logs.text = logs_text
 		$FinalReport/VBoxContainer/Logs.show()
 	else:
 		$FinalReport/VBoxContainer/Logs.hide()
-	
+
 	#Setup the rest of the popup
 	$FinalReport/VBoxContainer/ModuleName.text = "You completed the \"" + current_module.name + "\" module!"
 	$FinalReport/VBoxContainer/ModuleIcon.texture = current_module.thumbnail
@@ -218,16 +199,16 @@ func _on_FinalReport_RestartModuleButton_pressed() -> void:
 	$FinalReport.hide()
 
 func _on_FinalReport_ContinueButton_pressed() -> void:
-	$FinalReport.hide()
+	_switch_to_menu_page($MenuPages/MainMenu)
 
 func _on_About_CloseButton_pressed() -> void:
 	$AboutScreen.hide()
 
 func _on_OptionsButton_pressed() -> void:
-	$OptionsScreen.show()
-	$OptionsScreen/VBoxContainer/MouseDragToggle.button_pressed = GameSettings.mouse_camera_drag
-	$OptionsScreen/VBoxContainer/ObjectTooltipsToggle.button_pressed = GameSettings.object_tooltips
-	$OptionsScreen/VBoxContainer/PopupDuration/PopupTimeout.value = GameSettings.popup_timeout
+	_switch_to_menu_page($MenuPages/OptionsScreen)
+	$MenuPages/OptionsScreen/VBoxContainer/MouseDragToggle.button_pressed = GameSettings.mouse_camera_drag
+	$MenuPages/OptionsScreen/VBoxContainer/ObjectTooltipsToggle.button_pressed = GameSettings.object_tooltips
+	$MenuPages/OptionsScreen/VBoxContainer/PopupDuration/PopupTimeout.value = GameSettings.popup_timeout
 
 func _on_CloseButton_pressed() -> void:
 	$OptionsScreen.hide()
@@ -245,4 +226,25 @@ static func log_category_to_string(category: LogMessage.Category) -> String:
 	return LogMessage.Category.keys()[category].to_lower()
 
 func _on_exit_module_button_pressed() -> void:
-	$"..".return_to_menu()
+	_switch_to_main_menu()
+
+func _switch_to_main_menu() -> void:
+	$"..".unload_current_module()
+
+	_switch_to_menu_page($MenuPages/MainMenu)
+	$MenuPages/MainMenu/Content/Logo.hide()
+	$MenuPages/MainMenu/Content/ExitModuleButton.show()
+	$MenuPages/MainMenu/Background.show()
+
+	$LogButton.hide() #until we load a module
+	$LogButton/LogMenu.hide()
+	$FinalReport.hide()
+	$LabLogPopup.hide()
+
+# Only one of the UI elements in `$MenuPages` can be shown at once. These are
+# the UI elements that show up in the middle of the screen, and them overlapping is problematic.
+func _switch_to_menu_page(menu: Control) -> void:
+	if not $MenuPages.contains(menu): return
+	for m in $MenuPages.get_children():
+		m.hide()
+	menu.show()

--- a/project/source/Scripts/UI/Menu.gd
+++ b/project/source/Scripts/UI/Menu.gd
@@ -66,8 +66,8 @@ func _process(delta: float) -> void:
 func _unhandled_key_input(e: InputEvent) -> void:
 	if e.is_action_pressed(&"ToggleMenu"):
 		# A page other than the main pause menu is being shown; return to the pause menu.
-		if $MenuPages.visible and not $MenuPages/MainMenu.visible:
-			_switch_to_menu_page($MenuPages/MainMenu)
+		if $MenuPages.visible and not $MenuPages/PauseMenu.visible:
+			_switch_to_menu_page($MenuPages/PauseMenu)
 		# Toggle the pause menu only if we're in a module.
 		elif $"..".current_module_scene != null:
 			$MenuPages.visible = not $MenuPages.visible
@@ -75,10 +75,10 @@ func _unhandled_key_input(e: InputEvent) -> void:
 func _load_module(module: ModuleData) -> void:
 	get_parent().set_scene(module.scene)
 
-	_switch_to_menu_page($MenuPages/MainMenu)
+	_switch_to_menu_page($MenuPages/PauseMenu)
 	$Background.hide()
-	$MenuPages/MainMenu/Content/Logo.show()
-	$MenuPages/MainMenu/Content/ExitModuleButton.show()
+	$MenuPages/PauseMenu/Content/Logo.show()
+	$MenuPages/PauseMenu/Content/ExitModuleButton.show()
 	$MenuPages.hide()
 
 	current_module = module
@@ -204,10 +204,10 @@ func _on_FinalReport_RestartModuleButton_pressed() -> void:
 	$FinalReport.hide()
 
 func _on_FinalReport_ContinueButton_pressed() -> void:
-	_switch_to_menu_page($MenuPages/MainMenu)
+	_switch_to_menu_page($MenuPages/PauseMenu)
 
 func _on_About_CloseButton_pressed() -> void:
-	_switch_to_menu_page($MenuPages/MainMenu)
+	_switch_to_menu_page($MenuPages/PauseMenu)
 
 func _on_OptionsButton_pressed() -> void:
 	_switch_to_menu_page($MenuPages/OptionsScreen)
@@ -216,7 +216,7 @@ func _on_OptionsButton_pressed() -> void:
 	$MenuPages/OptionsScreen/VBoxContainer/PopupDuration/PopupTimeout.value = GameSettings.popup_timeout
 
 func _on_CloseButton_pressed() -> void:
-	_switch_to_menu_page($MenuPages/MainMenu)
+	_switch_to_menu_page($MenuPages/PauseMenu)
 
 func _on_MouseDragToggle_toggled(button_pressed: bool) -> void:
 	GameSettings.mouse_camera_drag = button_pressed
@@ -236,9 +236,9 @@ func _on_exit_module_button_pressed() -> void:
 func _switch_to_main_menu() -> void:
 	$"..".unload_current_module()
 
-	_switch_to_menu_page($MenuPages/MainMenu)
-	$MenuPages/MainMenu/Content/Logo.hide()
-	$MenuPages/MainMenu/Content/ExitModuleButton.hide()
+	_switch_to_menu_page($MenuPages/PauseMenu)
+	$MenuPages/PauseMenu/Content/Logo.hide()
+	$MenuPages/PauseMenu/Content/ExitModuleButton.hide()
 	$Background.show()
 
 	$LogButton.hide() #until we load a module


### PR DESCRIPTION
This PR:
- Adds buttons to the pause menu for exiting the current module, restarting the current module, and quitting the game.
- Moves the module select screen into a panel.
- Prevents menu UI elements from covering each other.
- Fixes an issue where the VIABLE logo was not visible in the pause menu while in a module.