### PR TITLE
Fix slides not showing and logging while hovering over the computer.

### DIFF
--- a/project/source/Scenes/Objects/Computer.tscn
+++ b/project/source/Scenes/Objects/Computer.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=15 format=3 uid="uid://dtltidc1e8ikc"]
+[gd_scene load_steps=16 format=3 uid="uid://dtltidc1e8ikc"]
 
 [ext_resource type="Script" path="res://Scenes/Objects/computer.gd" id="1_qhp2f"]
 [ext_resource type="Texture2D" uid="uid://cqmb14y7dw7nj" path="res://Images/Computer_Screen.png" id="2_pfloe"]
@@ -9,6 +9,7 @@
 [ext_resource type="FontFile" uid="uid://c5jqyemsa330f" path="res://UI/Roboto/Roboto-Black.ttf" id="10_scboh"]
 [ext_resource type="PackedScene" uid="uid://bh6iocygbfwtj" path="res://Scenes/UI/ChannelsPanel.tscn" id="10_t3byj"]
 [ext_resource type="PackedScene" uid="uid://b6ak8mmd81jv2" path="res://Scenes/UI/PowerExposure.tscn" id="11_anhd5"]
+[ext_resource type="Texture2D" uid="uid://c2qcmpwlsk2m1" path="res://Images/ImageCells/EmptySlide.jpg" id="11_bxcud"]
 [ext_resource type="Texture2D" uid="uid://bn0mca24purdc" path="res://Images/Play_Button.png" id="14_1rr6n"]
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_i5bsf"]
@@ -199,6 +200,7 @@ offset_bottom = 500.0
 grow_horizontal = 2
 grow_vertical = 2
 size_flags_horizontal = 3
+texture = ExtResource("11_bxcud")
 expand_mode = 1
 metadata/_edit_lock_ = true
 

--- a/project/source/Scenes/Objects/computer.gd
+++ b/project/source/Scenes/Objects/computer.gd
@@ -200,7 +200,7 @@ func create_combo_image() -> Image:
 		if current_slide == null:
 			image_path = "res://Images/ImageCells/EmptySlide.jpg"
 		else:
-			image_path = "res://Images/ImageCells/BPAE/%s/%s/%s.jpg" %[current_slide.slide_name, current_channel, zoom_level]
+			image_path = "res://Images/ImageCells/BPAE/%s/%s/%s.jpg" %[current_slide.slide_name, channel, zoom_level]
 		var img: Image = Image.new()
 		var img_resource := ResourceLoader.load(image_path)
 		img = img_resource.get_image()

--- a/project/source/Scenes/Objects/computer.gd
+++ b/project/source/Scenes/Objects/computer.gd
@@ -50,8 +50,8 @@ func _on_focus_control_focus_changed(level: float) -> void:
 
 # Emits a signal to the FlourescenceMicroscope Node, used to zoom into the computer screen
 func _on_input_event(_viewport: Node, event: InputEvent, _shape_idx: int) -> void:
-	LabLog.log("Entered computer", true, false)
 	if event is InputEventMouseButton and event.pressed and not is_clicked:
+		LabLog.log("Entered computer", true, false)
 		$Screen.show()
 		is_clicked = true
 		

--- a/project/source/Scenes/Objects/microscope.tscn
+++ b/project/source/Scenes/Objects/microscope.tscn
@@ -38,3 +38,4 @@ slide_tray_right_open_light_on = ExtResource("5_kmy0n")
 slide_tray_left_open_light_on = ExtResource("6_qrrim")
 
 [connection signal="input_event" from="light_switch" to="microscope_slide_tray" method="_on_light_switch_input_event"]
+[connection signal="mount_slide" from="microscope_slide_tray" to="." method="_on_microscope_slide_tray_mount_slide"]

--- a/project/source/Scenes/UI/microscope_focus_blur.gdshader
+++ b/project/source/Scenes/UI/microscope_focus_blur.gdshader
@@ -35,12 +35,6 @@ void fragment() {
 
 		vec4 original_color = texture(TEXTURE, uv);
 		COLOR = mix(original_color, blurred_color, blur_amount);
-
-		// Changing brightness
-		vec4 color = texture(TEXTURE, 	UV);
-		color.rgb += vec3(brightness);
-		COLOR = color;
-		// End of changing brightness
+		COLOR.rgb += vec3(brightness);
 	}
-
 }

--- a/project/source/Scenes/UI/microscope_focus_blur.gdshader
+++ b/project/source/Scenes/UI/microscope_focus_blur.gdshader
@@ -35,6 +35,7 @@ void fragment() {
 
 		vec4 original_color = texture(TEXTURE, uv);
 		COLOR = mix(original_color, blurred_color, blur_amount);
-		COLOR.rgb += vec3(brightness);
 	}
+
+	COLOR.rgb += vec3(brightness);
 }

--- a/project/source/Scripts/Objects/microscope_slide_tray.gd
+++ b/project/source/Scripts/Objects/microscope_slide_tray.gd
@@ -58,13 +58,13 @@ func _on_whole_area_body_entered(body: Node2D) -> void:
 	if right_open and left_open:
 		slide = body
 		can_slide_mount = true
-		LabLog.log("Slide " + slide.slide_name + " can mount", false, false)
+		LabLog.log("Slide can mount", false, false)
 	else:
-		LabLog.log("Slide " + slide.slide_name + " cannot mount", false, false)
+		LabLog.log("Slide cannot mount", false, false)
 		can_slide_mount = false
 
 func _on_whole_area_body_exited(body: Node2D) -> void:
-		LabLog.log("Slide " + slide.slide_name + " removed", false, false)
+		LabLog.log("Slide removed", false, false)
 		can_slide_mount = false
 		mount_slide.emit(null)
 


### PR DESCRIPTION
- Fix the microscope signal connection that was accidentally deleted.
- Fix constant log messages appearing when hovering over the computer.
- Fix a crash when a slide is dragged on top of the closed microscope doors at the start of the simulation.
- Fix brightness overriding blur in the shader.
- Fix a crash when running the combo channel.