### PR TITLE
Microwave Camera Zoom

### DIFF
--- a/project/source/Main.tscn
+++ b/project/source/Main.tscn
@@ -1,6 +1,6 @@
 [gd_scene load_steps=21 format=3 uid="uid://ch4jildorp0b3"]
 
-[ext_resource type="Script" uid="uid://cwl3oiayip31e" path="res://Scripts/UI/Menu.gd" id="1"]
+[ext_resource type="Script" uid="uid://crqlu3uq74012" path="res://Scripts/UI/Menu.gd" id="1"]
 [ext_resource type="Script" uid="uid://xvdl5qhq7itj" path="res://Main.gd" id="2"]
 [ext_resource type="Script" uid="uid://dwrt1nvnkb1nd" path="res://Scripts/Resources/MistakeChecker.gd" id="2_45sle"]
 [ext_resource type="Texture2D" uid="uid://bdg0qubi6xt7d" path="res://Images/MainMenu-Background.png" id="3"]

--- a/project/source/Scenes/Modules/combined.tscn
+++ b/project/source/Scenes/Modules/combined.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=20 format=3 uid="uid://bnn7yyuvh6jsj"]
+[gd_scene load_steps=21 format=3 uid="uid://bnn7yyuvh6jsj"]
 
 [ext_resource type="Texture2D" uid="uid://mba7i08n5ag6" path="res://Images/Resized_Images/Background.png" id="1_5wocf"]
 [ext_resource type="PackedScene" uid="uid://b5ff3gy87ykja" path="res://combined_scenes/flask.tscn" id="2_e4xug"]
@@ -17,6 +17,7 @@
 [ext_resource type="PackedScene" uid="uid://c1af3h23bqbvv" path="res://combined_scenes/scoopula.tscn" id="15_aby4o"]
 [ext_resource type="PackedScene" uid="uid://gfmuo2b5e2b5" path="res://combined_scenes/scale.tscn" id="16_c15s6"]
 [ext_resource type="PackedScene" uid="uid://dqc2dtt648v3m" path="res://combined_scenes/biohazard_bin.tscn" id="17_6se67"]
+[ext_resource type="Script" uid="uid://b8kjtd0vdnq42" path="res://combined_scripts/transition_camera.gd" id="18_1qt3r"]
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_5wocf"]
 size = Vector2(1430, 222)
@@ -104,3 +105,12 @@ position = Vector2(1143, 318)
 
 [node name="BiohazardBin" parent="." instance=ExtResource("17_6se67")]
 position = Vector2(83, 66)
+
+[node name="MainSceneCamera" type="Camera2D" parent="."]
+position = Vector2(640, 360)
+
+[node name="TransitionCamera" type="Camera2D" parent="." node_paths=PackedStringArray("main_scene_camera")]
+position = Vector2(641, 360)
+offset = Vector2(0.78, 0)
+script = ExtResource("18_1qt3r")
+main_scene_camera = NodePath("../MainSceneCamera")

--- a/project/source/Scripts/UI/Menu.gd
+++ b/project/source/Scripts/UI/Menu.gd
@@ -81,7 +81,7 @@ func _process(delta: float) -> void:
 				cc.mix(delta)
 
 func _unhandled_key_input(e: InputEvent) -> void:
-	if e.is_action_pressed(&"ToggleMenu"):
+	if e.is_action_pressed(&"ToggleMenu") and not GameState.is_camera_zoomed:
 		# A page other than the main pause menu is being shown; return to the pause menu.
 		if $MenuScreens.visible and not $MenuScreens/PauseMenu.visible:
 			_switch_to_menu_screen($MenuScreens/PauseMenu)

--- a/project/source/combined_scenes/microwave.tscn
+++ b/project/source/combined_scenes/microwave.tscn
@@ -2,12 +2,14 @@
 
 [ext_resource type="Texture2D" uid="uid://bnjnwv1adqmky" path="res://Images/Resized_Images/Microwave_closed.png" id="1_a0lrr"]
 [ext_resource type="Script" uid="uid://p0x2f70nn1sy" path="res://combined_scripts/selectable_canvas_group.gd" id="2_cwbd0"]
-[ext_resource type="Script" uid="uid://bsonh03rfuf2p" path="res://combined_scripts/drag_component.gd" id="2_d8lky"]
 [ext_resource type="Script" uid="uid://6sh30cc4wi2" path="res://combined_scripts/interaction_area.gd" id="4_iwbat"]
 [ext_resource type="Script" uid="uid://ddnlp8fmwwyw8" path="res://combined_scripts/microwave_interaction.gd" id="5_iwbat"]
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_a0lrr"]
 size = Vector2(273, 152)
+
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_iwbat"]
+size = Vector2(49, 59)
 
 [node name="Microwave" type="RigidBody2D"]
 collision_layer = 0
@@ -15,12 +17,6 @@ collision_layer = 0
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
 position = Vector2(1.5, 3)
 shape = SubResource("RectangleShape2D_a0lrr")
-
-[node name="DragComponent" type="Node2D" parent="." node_paths=PackedStringArray("body", "interact_canvas_group")]
-script = ExtResource("2_d8lky")
-body = NodePath("..")
-interact_canvas_group = NodePath("../SelectableCanvasGroup")
-metadata/_custom_type_script = "uid://bsonh03rfuf2p"
 
 [node name="SelectableCanvasGroup" type="CanvasGroup" parent="."]
 script = ExtResource("2_cwbd0")
@@ -64,6 +60,7 @@ columns = 3
 
 [node name="Button1" type="Button" parent="Keypad"]
 layout_mode = 2
+mouse_filter = 2
 text = "1"
 
 [node name="Button2" type="Button" parent="Keypad"]
@@ -117,14 +114,30 @@ text = "Start"
 
 [node name="MicrowaveTimer" type="Timer" parent="."]
 
-[node name="InteractionComponent" type="Node" parent="." node_paths=PackedStringArray("timer", "timer_label", "key_pad", "interaction_area", "body")]
+[node name="InteractionComponent" type="Node" parent="." node_paths=PackedStringArray("timer", "timer_label", "key_pad", "key_pad_area", "camera", "interaction_area", "body")]
 script = ExtResource("5_iwbat")
 timer = NodePath("../MicrowaveTimer")
 timer_label = NodePath("../TimerLabel")
 key_pad = NodePath("../Keypad")
+key_pad_area = NodePath("../KeypadArea")
+camera = NodePath("../ZoomCamera")
 interaction_area = NodePath("../InteractionArea")
 body = NodePath("..")
 metadata/_custom_type_script = "uid://bdcoyj8ye48sb"
 
+[node name="ZoomCamera" type="Camera2D" parent="."]
+editor_description = "A template for the TransitionCamera in Main to transition to when necessary."
+zoom = Vector2(4, 4)
+position_smoothing_speed = 1.0
+
+[node name="KeypadArea" type="Area2D" parent="."]
+monitoring = false
+monitorable = false
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="KeypadArea"]
+position = Vector2(106.5, -0.5)
+shape = SubResource("RectangleShape2D_iwbat")
+
 [connection signal="pressed" from="StopButton" to="InteractionComponent" method="_on_microwave_stopped"]
 [connection signal="timeout" from="MicrowaveTimer" to="InteractionComponent" method="_on_microwave_timer_timeout"]
+[connection signal="input_event" from="KeypadArea" to="InteractionComponent" method="_on_keypad_area_input_event"]

--- a/project/source/combined_scripts/microwave_interaction.gd
+++ b/project/source/combined_scripts/microwave_interaction.gd
@@ -12,6 +12,7 @@ var is_microwaving: bool = false
 var is_object_inside: bool = false
 var total_seconds_left: int = 0
 var total_seconds: int = 0
+var is_zoomed_in: bool = false
 
 func _ready() -> void:
 	super()
@@ -137,15 +138,19 @@ func update_timer_display(minutes: int, seconds: int) -> void:
 
 
 func _input(event: InputEvent) -> void:
-	if GameState.target_camera == camera and event.is_action_pressed("ExitCameraZoom"):
-		# If the keypad is not zoomed in, buttons can't be clicked on. 
+	if is_zoomed_in and event.is_action_pressed("ExitCameraZoom"):
+		is_zoomed_in = false
+		
+		# Buttons can't be clicked on if zoomed out. 
 		for button: Button in key_pad.get_children():
 			button.mouse_filter = Control.MOUSE_FILTER_IGNORE
 
-## Handles when the area is clicked on
+## Handles when the area is clicked on. If so zoom in on the microwave
 func _on_keypad_area_input_event(_viewport: Node, event: InputEvent, _shape_idx: int) -> void:
-	if event.is_action_pressed("click"):
+	if event.is_action_pressed("click") and not is_zoomed_in:
+		is_zoomed_in = true
 		GameState.target_camera = camera
+		
 		# Keypad buttons should be clickable if zoomed in on
 		for button: Button in key_pad.get_children():
 			button.mouse_filter = Control.MOUSE_FILTER_STOP

--- a/project/source/combined_scripts/microwave_interaction.gd
+++ b/project/source/combined_scripts/microwave_interaction.gd
@@ -1,8 +1,10 @@
 extends InteractionComponent
 ## Microwave Interaction
-@export var timer: Timer
-@export var timer_label: Label
-@export var key_pad: GridContainer
+@export var timer: Timer # Microwave Timer Node
+@export var timer_label: Label # TimerLabel
+@export var key_pad: GridContainer 
+@export var key_pad_area: Area2D # If clicked on, should activate zoom
+@export var camera: Camera2D
 
 var container_to_heat: ContainerComponent
 var input_time: int = 0
@@ -16,6 +18,7 @@ func _ready() -> void:
 	# Connect all buttons in the keypad
 	for button: Button in key_pad.get_children():
 		button.pressed.connect(_on_keypad_button_pressed.bind(button.text))
+		button.mouse_filter = Control.MOUSE_FILTER_IGNORE
 		
 func _process(_delta: float) -> void:
 	if body == GameState.interactable: # Something is interacting with the Microwave
@@ -131,3 +134,18 @@ func _on_keypad_button_pressed(button_value: String) -> void:
 
 func update_timer_display(minutes: int, seconds: int) -> void:
 	timer_label.text = "%d:%02d" % [minutes, seconds]
+
+
+func _input(event: InputEvent) -> void:
+	if GameState.target_camera == camera and event.is_action_pressed("ExitCameraZoom"):
+		# If the keypad is not zoomed in, buttons can't be clicked on. 
+		for button: Button in key_pad.get_children():
+			button.mouse_filter = Control.MOUSE_FILTER_IGNORE
+
+## Handles when the area is clicked on
+func _on_keypad_area_input_event(_viewport: Node, event: InputEvent, _shape_idx: int) -> void:
+	if event.is_action_pressed("click"):
+		GameState.target_camera = camera
+		# Keypad buttons should be clickable if zoomed in on
+		for button: Button in key_pad.get_children():
+			button.mouse_filter = Control.MOUSE_FILTER_STOP

--- a/project/source/combined_scripts/states.gd
+++ b/project/source/combined_scripts/states.gd
@@ -3,3 +3,5 @@ extends Node
 var is_dragging: bool
 var interactor: PhysicsBody2D # The object being dragged on top of other objects
 var interactable: PhysicsBody2D # The object that is being interacted with
+var target_camera: Camera2D # Used for zooming in on certain objects. We need that objects camera properties for a smooth transition
+var is_camera_zoomed: bool

--- a/project/source/combined_scripts/transition_camera.gd
+++ b/project/source/combined_scripts/transition_camera.gd
@@ -1,0 +1,33 @@
+extends Camera2D
+## This TransitionCamera will always be the active camera. 
+## Its purpose is to move and change zoom based on other Camera2ds and their properties
+
+@export var main_scene_camera: Camera2D
+var current_camera: Camera2D
+func _ready() -> void:
+	make_current() 
+
+func _process(_delta: float) -> void:
+	if GameState.target_camera and current_camera != GameState.target_camera:
+		change_camera(GameState.target_camera)
+		GameState.is_camera_zoomed = true
+	
+func _input(event: InputEvent) -> void:
+	# Unzoom camera
+	if event.is_action_pressed("ExitCameraZoom") and current_camera != main_scene_camera:
+		GameState.target_camera = main_scene_camera
+		change_camera(main_scene_camera)
+		
+## Transition the TransitionCamera and its properties to the target camera
+func change_camera(target_camera: Camera2D) -> void:
+	current_camera = target_camera
+	var position_tween: Tween = create_tween()
+	var zoom_tween: Tween = create_tween()
+	
+	position_tween.tween_property(self, "position", target_camera.global_position, 1)
+	zoom_tween.tween_property(self, "zoom", target_camera.zoom, 1).set_ease(Tween.EASE_IN_OUT)
+	await position_tween.finished
+
+	# Prevents opening of menu via escape until the tweens are finished
+	if target_camera == main_scene_camera:
+		GameState.is_camera_zoomed = false

--- a/project/source/combined_scripts/transition_camera.gd.uid
+++ b/project/source/combined_scripts/transition_camera.gd.uid
@@ -1,0 +1,1 @@
+uid://b8kjtd0vdnq42

--- a/project/source/project.godot
+++ b/project/source/project.godot
@@ -105,6 +105,12 @@ mix_container={
 ]
 }
 
+ExitCameraZoom={
+"deadzone": 0.2,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194305,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
+]
+}
+
 [layer_names]
 
 2d_physics/layer_1="Scene"

--- a/project/source/project.godot
+++ b/project/source/project.godot
@@ -104,10 +104,9 @@ mix_container={
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":77,"physical_keycode":0,"key_label":0,"unicode":109,"location":0,"echo":false,"script":null)
 ]
 }
-
 ExitCameraZoom={
 "deadzone": 0.2,
-"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194305,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":4194305,"physical_keycode":0,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
 ]
 }
 


### PR DESCRIPTION
When clicking on the keypad of the microwave, the camera will zoom in on the microwave and allow the user to click on the buttons. Likewise, if it's zoomed out, the buttons will not accept clicks. 

Added a TransitionCamera to the combined scene. This is always the active camera and is the one moving and changing zoom properties. Other Camera2d nodes are not used and instead exist purely as a way to give information about position and zoom to the TransitionCamera.