### PR TITLE
Minor Tweaks and Simple Pipette Box Interaction

### DIFF
--- a/project/source/Main.tscn
+++ b/project/source/Main.tscn
@@ -1,6 +1,6 @@
 [gd_scene load_steps=21 format=3 uid="uid://ch4jildorp0b3"]
 
-[ext_resource type="Script" uid="uid://cwl3oiayip31e" path="res://Scripts/UI/Menu.gd" id="1"]
+[ext_resource type="Script" uid="uid://crqlu3uq74012" path="res://Scripts/UI/Menu.gd" id="1"]
 [ext_resource type="Script" uid="uid://xvdl5qhq7itj" path="res://Main.gd" id="2"]
 [ext_resource type="Script" uid="uid://dwrt1nvnkb1nd" path="res://Scripts/Resources/MistakeChecker.gd" id="2_45sle"]
 [ext_resource type="Texture2D" uid="uid://bdg0qubi6xt7d" path="res://Images/MainMenu-Background.png" id="3"]

--- a/project/source/combined_scenes/flask.tscn
+++ b/project/source/combined_scenes/flask.tscn
@@ -32,7 +32,7 @@ metadata/_custom_type_script = "uid://p0x2f70nn1sy"
 [node name="ErlenmeyerflaskContainer" type="Sprite2D" parent="SelectableCanvasGroup"]
 texture = ExtResource("1_cfopd")
 
-[node name="InteractionComponent" type="Node" parent="." node_paths=PackedStringArray("interaction_area", "body")]
+[node name="InteractionComponent" type="Node2D" parent="." node_paths=PackedStringArray("interaction_area", "body")]
 script = ExtResource("5_p00t2")
 interaction_area = NodePath("../InteractionArea")
 body = NodePath("..")

--- a/project/source/combined_scenes/microwave.tscn
+++ b/project/source/combined_scenes/microwave.tscn
@@ -117,14 +117,14 @@ text = "Start"
 
 [node name="MicrowaveTimer" type="Timer" parent="."]
 
-[node name="InteractionComponent" type="Node" parent="." node_paths=PackedStringArray("timer", "timer_label", "key_pad", "interaction_area", "body")]
+[node name="MicrowaveInteraction" type="Node2D" parent="." node_paths=PackedStringArray("timer", "timer_label", "key_pad", "interaction_area", "body")]
 script = ExtResource("5_iwbat")
 timer = NodePath("../MicrowaveTimer")
 timer_label = NodePath("../TimerLabel")
 key_pad = NodePath("../Keypad")
 interaction_area = NodePath("../InteractionArea")
 body = NodePath("..")
-metadata/_custom_type_script = "uid://bdcoyj8ye48sb"
+metadata/_custom_type_script = "uid://ddnlp8fmwwyw8"
 
-[connection signal="pressed" from="StopButton" to="InteractionComponent" method="_on_microwave_stopped"]
-[connection signal="timeout" from="MicrowaveTimer" to="InteractionComponent" method="_on_microwave_timer_timeout"]
+[connection signal="pressed" from="StopButton" to="MicrowaveInteraction" method="_on_microwave_stopped"]
+[connection signal="timeout" from="MicrowaveTimer" to="MicrowaveInteraction" method="_on_microwave_timer_timeout"]

--- a/project/source/combined_scenes/pipette.tscn
+++ b/project/source/combined_scenes/pipette.tscn
@@ -1,16 +1,23 @@
-[gd_scene load_steps=6 format=3 uid="uid://t5vephauatf2"]
+[gd_scene load_steps=8 format=3 uid="uid://t5vephauatf2"]
 
 [ext_resource type="Texture2D" uid="uid://b35y8esb054uy" path="res://Images/Resized_Images/Pipette_with_tip.png" id="1_da3ja"]
+[ext_resource type="Script" uid="uid://bvktn342w1r7o" path="res://combined_scripts/pipette.gd" id="1_y22yk"]
 [ext_resource type="Script" uid="uid://p0x2f70nn1sy" path="res://combined_scripts/selectable_canvas_group.gd" id="2_drsrt"]
 [ext_resource type="Script" uid="uid://bsonh03rfuf2p" path="res://combined_scripts/drag_component.gd" id="2_h00ti"]
+[ext_resource type="Texture2D" uid="uid://ndoyd04ilqyo" path="res://Images/Resized_Images/Pipette_with_notip.png" id="4_5ngtk"]
 [ext_resource type="Script" uid="uid://6sh30cc4wi2" path="res://combined_scripts/interaction_area.gd" id="4_yutq4"]
-[ext_resource type="Script" uid="uid://bdcoyj8ye48sb" path="res://combined_scripts/interaction_component.gd" id="5_y22yk"]
+[ext_resource type="Script" uid="uid://bdcoyj8ye48sb" path="res://combined_scripts/interaction_component.gd" id="7_5ngtk"]
 
-[node name="RigidBody2D" type="RigidBody2D"]
+[node name="Pipette" type="RigidBody2D"]
 collision_layer = 0
+script = ExtResource("1_y22yk")
 
-[node name="CollisionPolygon2D" type="CollisionPolygon2D" parent="."]
+[node name="CollisionPolygon2DNoTip" type="CollisionPolygon2D" parent="."]
+polygon = PackedVector2Array(4, 60, 9, -10, 13, -10, 13, -71, -8, -71, -13, -64, -3, -64, -3, 1, 2, 60, 3, 61)
+
+[node name="CollisionPolygon2DWithTip" type="CollisionPolygon2D" parent="."]
 polygon = PackedVector2Array(-13, -64, -3, -64, -3, 2, 3, 80, 9, 3, 9, -10, 13, -10, 13, -71, -8, -71)
+disabled = true
 
 [node name="DragComponent" type="Node2D" parent="." node_paths=PackedStringArray("body", "interact_canvas_group")]
 script = ExtResource("2_h00ti")
@@ -22,7 +29,12 @@ metadata/_custom_type_script = "uid://bsonh03rfuf2p"
 script = ExtResource("2_drsrt")
 metadata/_custom_type_script = "uid://p0x2f70nn1sy"
 
+[node name="PipetteNoTip" type="Sprite2D" parent="SelectableCanvasGroup"]
+position = Vector2(0, -10)
+texture = ExtResource("4_5ngtk")
+
 [node name="PipetteWithTip" type="Sprite2D" parent="SelectableCanvasGroup"]
+visible = false
 texture = ExtResource("1_da3ja")
 
 [node name="InteractionArea" type="Area2D" parent="."]
@@ -30,10 +42,11 @@ script = ExtResource("4_yutq4")
 metadata/_custom_type_script = "uid://6sh30cc4wi2"
 
 [node name="CollisionPolygon2D" type="CollisionPolygon2D" parent="InteractionArea"]
+visible = false
 polygon = PackedVector2Array(-13, -64, -3, -64, -3, 2, 3, 80, 9, 3, 9, -10, 13, -10, 13, -71, -8, -71)
 
 [node name="InteractionComponent" type="Node2D" parent="." node_paths=PackedStringArray("interaction_area", "body")]
-script = ExtResource("5_y22yk")
+script = ExtResource("7_5ngtk")
 interaction_area = NodePath("../InteractionArea")
 body = NodePath("..")
 metadata/_custom_type_script = "uid://bdcoyj8ye48sb"

--- a/project/source/combined_scenes/pipette_tip_box.tscn
+++ b/project/source/combined_scenes/pipette_tip_box.tscn
@@ -4,7 +4,7 @@
 [ext_resource type="Script" uid="uid://p0x2f70nn1sy" path="res://combined_scripts/selectable_canvas_group.gd" id="2_3s6eo"]
 [ext_resource type="Script" uid="uid://bsonh03rfuf2p" path="res://combined_scripts/drag_component.gd" id="2_cxa2o"]
 [ext_resource type="Script" uid="uid://6sh30cc4wi2" path="res://combined_scripts/interaction_area.gd" id="4_s8ros"]
-[ext_resource type="Script" uid="uid://bdcoyj8ye48sb" path="res://combined_scripts/interaction_component.gd" id="5_f63uk"]
+[ext_resource type="Script" uid="uid://di0ooxn48b40x" path="res://combined_scripts/pipette_box_interaction.gd" id="5_s8ros"]
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_gs6p0"]
 size = Vector2(106, 43)
@@ -37,8 +37,8 @@ metadata/_custom_type_script = "uid://6sh30cc4wi2"
 position = Vector2(0, 15.5)
 shape = SubResource("RectangleShape2D_gs6p0")
 
-[node name="InteractionComponent" type="Node2D" parent="." node_paths=PackedStringArray("interaction_area", "body")]
-script = ExtResource("5_f63uk")
+[node name="PipetteBoxInteraction" type="Node2D" parent="." node_paths=PackedStringArray("interaction_area", "body")]
+script = ExtResource("5_s8ros")
 interaction_area = NodePath("../InteractionArea")
 body = NodePath("..")
-metadata/_custom_type_script = "uid://bdcoyj8ye48sb"
+metadata/_custom_type_script = "uid://di0ooxn48b40x"

--- a/project/source/combined_scripts/interaction_component.gd
+++ b/project/source/combined_scripts/interaction_component.gd
@@ -24,4 +24,5 @@ func _process(_delta: float) -> void:
 
 # Virtual. Should be implemented in the node that extends this class
 func interact(_interactor: PhysicsBody2D) -> void:
-	assert(false, "Please add interact() to the %s's script that extends InteractionComponent." % [interactable.name])
+	assert(false, "%s currently does not handle any interactions. \
+	Please add interact() to the %s's script that extends InteractionComponent." % [interactable.name, interactable.name])

--- a/project/source/combined_scripts/interaction_component.gd
+++ b/project/source/combined_scripts/interaction_component.gd
@@ -1,5 +1,9 @@
-extends Node
+extends Node2D
 class_name InteractionComponent
+
+## Acts as a base class that handles connecting the InteractionArea node to the InteractionHandler singleton
+## Also handles initial interaction setup in _process
+## All interaction nodes should extend this one
 
 @export var interaction_area: InteractionArea # The parent should always have an InteractionArea if this component is used
 @export var body: RigidBody2D # Should be the parent of this component
@@ -10,3 +14,14 @@ var interactor: PhysicsBody2D
 func _ready() -> void:
 	interaction_area.area_entered.connect(InteractionHandler._on_interaction_area_entered.bind(body))
 	interaction_area.area_exited.connect(InteractionHandler._on_interaction_area_exited.bind(body))
+
+func _process(_delta: float) -> void:
+	if body == GameState.interactable: # Something is interacting with the body
+		interactable = body
+		interactor = GameState.interactor
+		interact(interactor)
+		GameState.interactable = null
+
+# Virtual. Should be implemented in the node that extends this class
+func interact(_interactor: PhysicsBody2D) -> void:
+	assert(false, "Please add interact() to the %s's script that extends InteractionComponent." % [interactable.name])

--- a/project/source/combined_scripts/microwave_interaction.gd
+++ b/project/source/combined_scripts/microwave_interaction.gd
@@ -1,4 +1,6 @@
 extends InteractionComponent
+class_name MicrowaveInteraction
+
 ## Microwave Interaction
 @export var timer: Timer
 @export var timer_label: Label
@@ -17,20 +19,14 @@ func _ready() -> void:
 	for button: Button in key_pad.get_children():
 		button.pressed.connect(_on_keypad_button_pressed.bind(button.text))
 		
-func _process(_delta: float) -> void:
-	if body == GameState.interactable: # Something is interacting with the Microwave
-		if not is_object_inside:
-			interactable = body
-			interactor = GameState.interactor
-			interact(interactor)
-		else:
-			print("Something is already inside the microwave!")
-			
-		GameState.interactable = null
+
 
 func interact(interactor: PhysicsBody2D) -> void:
+	if is_object_inside:
+		print("Something is already inside the microwave!")
+		return
+		
 	container_to_heat = find_container(interactor)
-	
 	if container_to_heat:
 		is_object_inside = true
 		
@@ -59,11 +55,12 @@ func _on_start_button_pressed() -> void:
 
 ## Triggered either by the "stop" button or the timer ran out
 func _on_microwave_stopped() -> void:
+	interactor.set_deferred(&"visible", true)
+	is_object_inside = false
+	
 	if is_microwaving:
 		timer.stop()
 		is_microwaving = false
-		interactor.set_deferred(&"visible", true)
-		is_object_inside = false
 
 		# TODO: This calculation should be handled by the `ContainerComponent` and substances
 		# themselves.

--- a/project/source/combined_scripts/pipette.gd
+++ b/project/source/combined_scripts/pipette.gd
@@ -1,0 +1,13 @@
+extends RigidBody2D
+class_name Pipe # TODO: Since the old sinmulaton uses a class_name Pipette already, had to change the name. Should name it Pipette when the old stuff is gone
+
+var has_tip: bool = false:
+	set(value):
+		has_tip = value
+		
+		# Change sprites and active collision depending if it has_tip is true or false
+		$CollisionPolygon2DNoTip.disabled = value
+		$SelectableCanvasGroup/PipetteNoTip.visible = !value
+		
+		$CollisionPolygon2DWithTip.disabled = !value
+		$SelectableCanvasGroup/PipetteWithTip.visible = value

--- a/project/source/combined_scripts/pipette.gd.uid
+++ b/project/source/combined_scripts/pipette.gd.uid
@@ -1,0 +1,1 @@
+uid://bvktn342w1r7o

--- a/project/source/combined_scripts/pipette_box_interaction.gd
+++ b/project/source/combined_scripts/pipette_box_interaction.gd
@@ -1,0 +1,9 @@
+extends InteractionComponent
+class_name PipetteBoxInteraction
+
+func interact(interactor: PhysicsBody2D) -> void:
+	if interactor is Pipe:
+		interactor.has_tip = true	
+		
+	else:
+		print("Only Pipettes can interact with %s" % [interactable.name])

--- a/project/source/combined_scripts/pipette_box_interaction.gd.uid
+++ b/project/source/combined_scripts/pipette_box_interaction.gd.uid
@@ -1,0 +1,1 @@
+uid://di0ooxn48b40x


### PR DESCRIPTION
- Added more specific interaction types that extends InteractionComponent for the Microwave and Pipette Box

After our meeting with @AdaZhao1211, I realized that it was quite confusing just having an InteractionComponent type that had a specific interaction script attached. For example, the Microwave had the InteractionComponent node with the microwave_interaction.gd script attached to it. So, I decided to make a MicrowaveInteraction type with the microwave_interaction.gd script attached and add that to the Microwave, replacing the IntractionComponent. 

This approach would also help in making more generic interactions for certain groups of objects in the future. For example, a MeasuringContainerInteraction type can be applied to both flasks and graduated cylinders.

- Added process function and abstract interact function to the InteractionComponent for initial interaction handling.
    - If interact() is not implemented in the class that extends InteractionComponent, it will throw an error

-  Created a simple Pipette Box interaction
    -  If a Pipette is interacting with the Pipette Box, its sprite will change to having a tip and the collision is updated to match the sprite