### PR TITLE
Add a general system for placing objects in/on other objects

### DIFF
--- a/project/source/Scenes/Modules/combined.tscn
+++ b/project/source/Scenes/Modules/combined.tscn
@@ -104,6 +104,9 @@ position = Vector2(1032, 300)
 [node name="ScoopulaHolder" parent="." instance=ExtResource("14_82fmo")]
 position = Vector2(1025, 303)
 
+[node name="AttachmentInteractableArea" parent="ScoopulaHolder" index="0" node_paths=PackedStringArray("contained_object")]
+contained_object = NodePath("../../Scoopula")
+
 [node name="Scale" parent="." instance=ExtResource("16_c15s6")]
 position = Vector2(1142, 340)
 
@@ -150,4 +153,5 @@ offset = Vector2(0.78, 0)
 script = ExtResource("18_1qt3r")
 main_scene_camera = NodePath("../MainSceneCamera")
 
+[editable path="ScoopulaHolder"]
 [editable path="MicrocentrifugeHolder"]

--- a/project/source/Scenes/Modules/combined.tscn
+++ b/project/source/Scenes/Modules/combined.tscn
@@ -129,6 +129,18 @@ freeze = true
 [node name="MicrocentrifugeHolder" parent="." instance=ExtResource("18_xe06v")]
 position = Vector2(426, 557)
 
+[node name="AttachmentInteractableArea" parent="MicrocentrifugeHolder" index="0" node_paths=PackedStringArray("contained_object")]
+contained_object = NodePath("../../MicrocentrifugeTube")
+
+[node name="AttachmentInteractableArea2" parent="MicrocentrifugeHolder" index="1" node_paths=PackedStringArray("contained_object")]
+contained_object = NodePath("../../MicrocentrifugeTube2")
+
+[node name="AttachmentInteractableArea3" parent="MicrocentrifugeHolder" index="2" node_paths=PackedStringArray("contained_object")]
+contained_object = NodePath("../../MicrocentrifugeTube3")
+
+[node name="AttachmentInteractableArea4" parent="MicrocentrifugeHolder" index="3" node_paths=PackedStringArray("contained_object")]
+contained_object = NodePath("../../MicrocentrifugeTube4")
+
 [node name="MainSceneCamera" type="Camera2D" parent="."]
 position = Vector2(640, 360)
 
@@ -137,3 +149,5 @@ position = Vector2(641, 360)
 offset = Vector2(0.78, 0)
 script = ExtResource("18_1qt3r")
 main_scene_camera = NodePath("../MainSceneCamera")
+
+[editable path="MicrocentrifugeHolder"]

--- a/project/source/combined_scenes/microcentrifuge_holder.tscn
+++ b/project/source/combined_scenes/microcentrifuge_holder.tscn
@@ -1,8 +1,12 @@
-[gd_scene load_steps=5 format=3 uid="uid://bt321lhs647bu"]
+[gd_scene load_steps=7 format=3 uid="uid://bt321lhs647bu"]
 
 [ext_resource type="Script" uid="uid://b4dann3kdfg3k" path="res://combined_scripts/lab_body.gd" id="1_y0nf6"]
 [ext_resource type="Script" uid="uid://p0x2f70nn1sy" path="res://combined_scripts/selectable_canvas_group.gd" id="2_lhjef"]
+[ext_resource type="Script" uid="uid://ul3h2acp7c3y" path="res://combined_scripts/attachment_interactable_area.gd" id="2_ufhtq"]
 [ext_resource type="Texture2D" uid="uid://4gatp66jseq6" path="res://updated_assets/lab_objects/microcentrifuge_holder.svg" id="3_ufhtq"]
+
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_0swob"]
+size = Vector2(20, 54)
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_h3rdw"]
 size = Vector2(140, 57)
@@ -10,6 +14,54 @@ size = Vector2(140, 57)
 [node name="MicrocentrifugeHolder" type="RigidBody2D"]
 script = ExtResource("1_y0nf6")
 metadata/_custom_type_script = "uid://b4dann3kdfg3k"
+
+[node name="AttachmentInteractableArea" type="Area2D" parent="."]
+position = Vector2(-49, -18)
+script = ExtResource("2_ufhtq")
+allowed_point_groups = Array[StringName]([&"attachment:microcentrifuge_tube"])
+metadata/_custom_type_script = "uid://ul3h2acp7c3y"
+metadata/_edit_group_ = true
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="AttachmentInteractableArea"]
+position = Vector2(0, -13)
+shape = SubResource("RectangleShape2D_0swob")
+debug_color = Color(0.954008, 0.0952036, 0.484962, 0.42)
+
+[node name="AttachmentInteractableArea2" type="Area2D" parent="."]
+position = Vector2(-17, -18)
+script = ExtResource("2_ufhtq")
+allowed_point_groups = Array[StringName]([&"attachment:microcentrifuge_tube"])
+metadata/_custom_type_script = "uid://ul3h2acp7c3y"
+metadata/_edit_group_ = true
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="AttachmentInteractableArea2"]
+position = Vector2(0, -13)
+shape = SubResource("RectangleShape2D_0swob")
+debug_color = Color(0.954008, 0.0952036, 0.484962, 0.42)
+
+[node name="AttachmentInteractableArea3" type="Area2D" parent="."]
+position = Vector2(16, -18)
+script = ExtResource("2_ufhtq")
+allowed_point_groups = Array[StringName]([&"attachment:microcentrifuge_tube"])
+metadata/_custom_type_script = "uid://ul3h2acp7c3y"
+metadata/_edit_group_ = true
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="AttachmentInteractableArea3"]
+position = Vector2(0, -13)
+shape = SubResource("RectangleShape2D_0swob")
+debug_color = Color(0.954008, 0.0952036, 0.484962, 0.42)
+
+[node name="AttachmentInteractableArea4" type="Area2D" parent="."]
+position = Vector2(49, -18)
+script = ExtResource("2_ufhtq")
+allowed_point_groups = Array[StringName]([&"attachment:microcentrifuge_tube"])
+metadata/_custom_type_script = "uid://ul3h2acp7c3y"
+metadata/_edit_group_ = true
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="AttachmentInteractableArea4"]
+position = Vector2(0, -13)
+shape = SubResource("RectangleShape2D_0swob")
+debug_color = Color(0.954008, 0.0952036, 0.484962, 0.42)
 
 [node name="SelectableCanvasGroup" type="CanvasGroup" parent="."]
 script = ExtResource("2_lhjef")

--- a/project/source/combined_scenes/microcentrifuge_tube.tscn
+++ b/project/source/combined_scenes/microcentrifuge_tube.tscn
@@ -1,9 +1,10 @@
-[gd_scene load_steps=5 format=3 uid="uid://dbb4h6gqfr7wb"]
+[gd_scene load_steps=6 format=3 uid="uid://dbb4h6gqfr7wb"]
 
 [ext_resource type="Script" uid="uid://b4dann3kdfg3k" path="res://combined_scripts/lab_body.gd" id="1_v7kqd"]
 [ext_resource type="Script" uid="uid://bsonh03rfuf2p" path="res://combined_scripts/drag_component.gd" id="2_g55dw"]
 [ext_resource type="Script" uid="uid://p0x2f70nn1sy" path="res://combined_scripts/selectable_canvas_group.gd" id="2_w81e0"]
 [ext_resource type="Texture2D" uid="uid://d1kyht6iivf6s" path="res://updated_assets/lab_objects/microcentrifuge_tube.svg" id="4_f37ir"]
+[ext_resource type="Script" uid="uid://cvvkvehovfwuy" path="res://combined_scripts/attachment_point.gd" id="5_ulp6r"]
 
 [node name="MicrocentrifugeTube" type="RigidBody2D"]
 collision_layer = 0
@@ -27,3 +28,8 @@ metadata/_custom_type_script = "uid://p0x2f70nn1sy"
 position = Vector2(1, 0)
 scale = Vector2(0.149663, 0.149663)
 texture = ExtResource("4_f37ir")
+
+[node name="AttachmentPoint" type="Node2D" parent="." groups=["attachment:microcentrifuge_tube"]]
+position = Vector2(1, -11)
+script = ExtResource("5_ulp6r")
+metadata/_custom_type_script = "uid://cvvkvehovfwuy"

--- a/project/source/combined_scenes/microwave.tscn
+++ b/project/source/combined_scenes/microwave.tscn
@@ -1,10 +1,10 @@
 [gd_scene load_steps=8 format=3 uid="uid://cs2tep7cd3vxf"]
 
-[ext_resource type="Script" uid="uid://b4dann3kdfg3k" path="res://combined_scripts/lab_body.gd" id="1_caubw"]
+[ext_resource type="Script" uid="uid://b10fibv688ggy" path="res://combined_scripts/microwave.gd" id="1_caubw"]
 [ext_resource type="Script" uid="uid://p0x2f70nn1sy" path="res://combined_scripts/selectable_canvas_group.gd" id="2_cwbd0"]
 [ext_resource type="Texture2D" uid="uid://bruixvdw7rapf" path="res://updated_assets/lab_objects/microwave.svg" id="3_iwbat"]
 [ext_resource type="Texture2D" uid="uid://bd4nu6l1dgnec" path="res://updated_assets/icons_and_buttons/button_2.svg" id="5_caubw"]
-[ext_resource type="Script" uid="uid://kyg3yiaw5rp2" path="res://combined_scripts/microwave_interactable_area.gd" id="5_iwbat"]
+[ext_resource type="Script" uid="uid://b3sgxo0w05r88" path="res://combined_scripts/object_containment_interactable_area.gd" id="6_caubw"]
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_a0lrr"]
 size = Vector2(273, 152)
@@ -277,19 +277,17 @@ monitorable = false
 position = Vector2(104.5, -0.5)
 shape = SubResource("RectangleShape2D_iwbat")
 
-[node name="InteractableArea" type="Area2D" parent="." node_paths=PackedStringArray("body", "timer", "timer_label", "key_pad", "key_pad_area", "camera")]
-script = ExtResource("5_iwbat")
-body = NodePath("..")
-timer = NodePath("../MicrowaveTimer")
-timer_label = NodePath("../TimerLabel")
-key_pad = NodePath("../Keypad")
-key_pad_area = NodePath("../KeypadArea")
-camera = NodePath("../ZoomCamera")
+[node name="ObjectContainmentInteractableArea" type="Area2D" parent="." node_paths=PackedStringArray("selectable_canvas_group")]
+script = ExtResource("6_caubw")
+selectable_canvas_group = NodePath("../SelectableCanvasGroup")
+allow_all_bodies = true
+place_prompt = "Put in microwave"
+metadata/_custom_type_script = "uid://b3sgxo0w05r88"
 
-[node name="CollisionShape2D" type="CollisionShape2D" parent="InteractableArea"]
+[node name="CollisionShape2D" type="CollisionShape2D" parent="ObjectContainmentInteractableArea"]
 position = Vector2(1.5, 3)
 shape = SubResource("RectangleShape2D_a0lrr")
 
-[connection signal="pressed" from="StopButton" to="InteractableArea" method="_on_microwave_stopped"]
-[connection signal="timeout" from="MicrowaveTimer" to="InteractableArea" method="_on_microwave_timer_timeout"]
-[connection signal="input_event" from="KeypadArea" to="InteractableArea" method="_on_keypad_area_input_event"]
+[connection signal="pressed" from="StopButton" to="." method="_on_microwave_stopped"]
+[connection signal="timeout" from="MicrowaveTimer" to="." method="_on_microwave_timer_timeout"]
+[connection signal="input_event" from="KeypadArea" to="." method="_on_keypad_area_input_event"]

--- a/project/source/combined_scenes/scale.tscn
+++ b/project/source/combined_scenes/scale.tscn
@@ -1,10 +1,10 @@
-[gd_scene load_steps=10 format=3 uid="uid://gfmuo2b5e2b5"]
+[gd_scene load_steps=8 format=3 uid="uid://gfmuo2b5e2b5"]
 
 [ext_resource type="Script" uid="uid://bsonh03rfuf2p" path="res://combined_scripts/drag_component.gd" id="1_o87w1"]
 [ext_resource type="Script" uid="uid://b4dann3kdfg3k" path="res://combined_scripts/lab_body.gd" id="1_ssuie"]
 [ext_resource type="Script" uid="uid://p0x2f70nn1sy" path="res://combined_scripts/selectable_canvas_group.gd" id="2_ceiaq"]
-[ext_resource type="Texture2D" uid="uid://ceb3fqgxtqtqf" path="res://UpdatedAssets/LabObjects/Scale.svg" id="4_ssuie"]
-[ext_resource type="Texture2D" uid="uid://bd4nu6l1dgnec" path="res://UpdatedAssets/IconsAndButtons/Button_2.svg" id="7_vhatv"]
+[ext_resource type="Texture2D" uid="uid://ceb3fqgxtqtqf" path="res://updated_assets/lab_objects/scale.svg" id="4_ssuie"]
+[ext_resource type="Texture2D" uid="uid://bd4nu6l1dgnec" path="res://updated_assets/icons_and_buttons/button_2.svg" id="7_vhatv"]
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_ssuie"]
 size = Vector2(125, 34)

--- a/project/source/combined_scenes/scoopula.tscn
+++ b/project/source/combined_scenes/scoopula.tscn
@@ -5,7 +5,7 @@
 [ext_resource type="Script" uid="uid://p0x2f70nn1sy" path="res://combined_scripts/selectable_canvas_group.gd" id="2_g0l2j"]
 [ext_resource type="Texture2D" uid="uid://cak418sbeesy5" path="res://updated_assets/lab_objects/scoopula.svg" id="4_sbaom"]
 
-[node name="Scoopula" type="RigidBody2D"]
+[node name="Scoopula" type="RigidBody2D" groups=["attachment:scoopula"]]
 collision_layer = 0
 script = ExtResource("1_sbaom")
 metadata/_custom_type_script = "uid://b4dann3kdfg3k"

--- a/project/source/combined_scenes/scoopula_holder.tscn
+++ b/project/source/combined_scenes/scoopula_holder.tscn
@@ -1,8 +1,12 @@
-[gd_scene load_steps=5 format=3 uid="uid://cqwtudfa80qn"]
+[gd_scene load_steps=7 format=3 uid="uid://cqwtudfa80qn"]
 
 [ext_resource type="Script" uid="uid://b4dann3kdfg3k" path="res://combined_scripts/lab_body.gd" id="1_4aecl"]
 [ext_resource type="Script" uid="uid://p0x2f70nn1sy" path="res://combined_scripts/selectable_canvas_group.gd" id="2_epgyh"]
 [ext_resource type="Texture2D" uid="uid://b533er73htfu6" path="res://updated_assets/lab_objects/scoopula_holder.svg" id="3_jp3dn"]
+[ext_resource type="Script" uid="uid://ul3h2acp7c3y" path="res://combined_scripts/attachment_interactable_area.gd" id="4_epgyh"]
+
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_epgyh"]
+size = Vector2(27, 100)
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_4aecl"]
 size = Vector2(27, 80)
@@ -10,6 +14,17 @@ size = Vector2(27, 80)
 [node name="ScoopulaHolder" type="RigidBody2D"]
 script = ExtResource("1_4aecl")
 metadata/_custom_type_script = "uid://b4dann3kdfg3k"
+
+[node name="AttachmentInteractableArea" type="Area2D" parent="."]
+position = Vector2(7.5, 50)
+script = ExtResource("4_epgyh")
+allowed_body_groups = Array[StringName]([&"attachment:scoopula"])
+metadata/_custom_type_script = "uid://ul3h2acp7c3y"
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="AttachmentInteractableArea"]
+position = Vector2(0, -44)
+shape = SubResource("RectangleShape2D_epgyh")
+debug_color = Color(0.921745, 5.49653e-05, 0.690079, 0.42)
 
 [node name="SelectableCanvasGroup" type="CanvasGroup" parent="."]
 script = ExtResource("2_epgyh")

--- a/project/source/combined_scripts/attachment_interactable_area.gd
+++ b/project/source/combined_scripts/attachment_interactable_area.gd
@@ -48,7 +48,8 @@ func can_place(body: LabBody) -> bool:
 	return _find_attachment_offset(body) is Vector2
 
 func on_place_object() -> void:
-	Interaction.active_drag_component.stop_dragging()
+	if Interaction.active_drag_component:
+		Interaction.active_drag_component.stop_dragging()
 	contained_object.start_dragging()
 
 	var offset: Variant = _find_attachment_offset(contained_object)

--- a/project/source/combined_scripts/attachment_interactable_area.gd
+++ b/project/source/combined_scripts/attachment_interactable_area.gd
@@ -9,6 +9,7 @@ extends ObjectSlotInteractableArea
 
 
 var _remote_transform := RemoteTransform2D.new()
+var _ghost_sprite: Node2D = null
 
 
 func _ready() -> void:
@@ -19,6 +20,20 @@ func _physics_process(_delta: float) -> void:
 	# The user started dragging the contained object, so we release it.
 	if Interaction.active_drag_component and Interaction.active_drag_component.body == contained_object:
 		remove_object()
+
+func start_targeting(_k: InteractInfo.Kind) -> void:
+	if not Interaction.active_drag_component or not Interaction.active_drag_component.body:
+		return
+
+	var ap := _find_attachment_point(Interaction.active_drag_component.body)
+	if not ap: return
+
+	_ghost_sprite = Util.make_sprite_ghost(Interaction.active_drag_component.body)
+	_ghost_sprite.position = -ap.position
+	call_deferred(&"add_child", _ghost_sprite)
+
+func stop_targeting(_k: InteractInfo.Kind) -> void:
+	call_deferred(&"remove_child", _ghost_sprite)
 
 func can_place(body: LabBody) -> bool:
 	return _find_attachment_point(body) != null

--- a/project/source/combined_scripts/attachment_interactable_area.gd
+++ b/project/source/combined_scripts/attachment_interactable_area.gd
@@ -5,7 +5,15 @@ extends ObjectSlotInteractableArea
 ## `RemoteTransform2D`. This node should never be rotated nor scaled.
 
 
+## Any attachment point, regardless of group, will be able to attach to this.
+@export var allow_all_attachment_points: bool = false
+## If `allow_all_attachment_points` is not set to true, then only attachment points with these
+## groups will be allowed.
 @export var allowed_point_groups: Array[StringName] = []
+
+## Any `LabBody` will be able to directly attach to this.
+@export var allow_all_bodies: bool = false
+## If `allow_all_bodies` is not true, then only `LabBody`s in these groups can be attached.
 @export var allowed_body_groups: Array[StringName] = []
 
 
@@ -60,7 +68,7 @@ func _find_attachment_offset(body: LabBody) -> Variant:
 	var ap := _find_attachment_point(body)
 	if ap: return -ap.position
 
-	if not allowed_body_groups or allowed_body_groups.any(func(g: StringName) -> bool: return body.is_in_group(g)):
+	if allow_all_bodies or allowed_body_groups.any(func(g: StringName) -> bool: return body.is_in_group(g)):
 		var bbox := Util.get_bounding_box(body)
 		# Bottom of the box.
 		return -bbox.position - bbox.size * Vector2(0.5, 1.0)
@@ -70,7 +78,7 @@ func _find_attachment_offset(body: LabBody) -> Variant:
 
 func _find_attachment_point(body: LabBody) -> AttachmentPoint:
 	for a: AttachmentPoint in body.find_children("", "AttachmentPoint", false):
-		if not allowed_point_groups or allowed_point_groups.any(func(g: StringName) -> bool: return a.is_in_group(g)):
+		if allow_all_attachment_points or allowed_point_groups.any(func(g: StringName) -> bool: return a.is_in_group(g)):
 			return a
 	
 	return null

--- a/project/source/combined_scripts/attachment_interactable_area.gd
+++ b/project/source/combined_scripts/attachment_interactable_area.gd
@@ -1,0 +1,43 @@
+class_name AttachmentInteractableArea
+extends ObjectSlotInteractableArea
+## If an object has a child of type `AttachmentPoint`, then it can be attached to this node such
+## that its attachment point is locked to the position of this node, held in place using a
+## `RemoteTransform2D`. This node should never be rotated nor scaled.
+
+
+@export var allowed_groups: Array[StringName] = []
+
+
+var _remote_transform := RemoteTransform2D.new()
+
+
+func _ready() -> void:
+	super()
+	call_deferred(&"add_child", _remote_transform)
+
+func _physics_process(_delta: float) -> void:
+	# The user started dragging the contained object, so we release it.
+	if Interaction.active_drag_component and Interaction.active_drag_component.body == contained_object:
+		remove_object()
+
+func can_place(body: LabBody) -> bool:
+	return _find_attachment_point(body) != null
+
+func on_place_object() -> void:
+	Interaction.active_drag_component.stop_dragging()
+	contained_object.start_dragging()
+
+	var ap := _find_attachment_point(contained_object)
+	if ap:
+		_remote_transform.position = -ap.position
+		_remote_transform.remote_path = contained_object.get_path()
+
+func on_remove_object() -> void:
+	_remote_transform.remote_path = NodePath()
+
+func _find_attachment_point(body: LabBody) -> AttachmentPoint:
+	for a: AttachmentPoint in body.find_children("", "AttachmentPoint", false):
+		if not allowed_groups or allowed_groups.any(func(g: StringName) -> bool: return a.is_in_group(g)):
+			return a
+	
+	return null

--- a/project/source/combined_scripts/attachment_interactable_area.gd.uid
+++ b/project/source/combined_scripts/attachment_interactable_area.gd.uid
@@ -1,0 +1,1 @@
+uid://ul3h2acp7c3y

--- a/project/source/combined_scripts/attachment_point.gd
+++ b/project/source/combined_scripts/attachment_point.gd
@@ -1,0 +1,4 @@
+class_name AttachmentPoint
+extends Node2D
+## Used as a point that can be attached to an `AttachmentInteractableArea`. If an attachment area
+## has any groups in `allowed_groups`, then this node must be in that group to be attached.

--- a/project/source/combined_scripts/attachment_point.gd.uid
+++ b/project/source/combined_scripts/attachment_point.gd.uid
@@ -1,0 +1,1 @@
+uid://cvvkvehovfwuy

--- a/project/source/combined_scripts/drag_component.gd
+++ b/project/source/combined_scripts/drag_component.gd
@@ -58,7 +58,6 @@ func stop_dragging() -> void:
 	body.stop_dragging()
 	Interaction.active_drag_component = null
 	Interaction.clear_interaction_stack()
-	interact_canvas_group.is_outlined = true
 	body.set_deferred(&"linear_velocity", _velocity / 5.0)
 
 func is_active() -> bool: return Interaction.active_drag_component == self

--- a/project/source/combined_scripts/drag_component.gd
+++ b/project/source/combined_scripts/drag_component.gd
@@ -39,6 +39,9 @@ func get_interactions() -> Array[InteractInfo]:
 	if is_active(): return [_put_down_interaction]
 	else: return [_pick_up_interaction]
 
+func start_targeting(_k: InteractInfo.Kind) -> void:
+	if not is_active(): interact_canvas_group.is_outlined = true
+
 func start_dragging() -> void:
 	body.start_dragging()
 	Interaction.active_drag_component = self

--- a/project/source/combined_scripts/microwave.gd
+++ b/project/source/combined_scripts/microwave.gd
@@ -1,11 +1,11 @@
 extends LabBody
 
 
-var input_time: int = 0
-var is_microwaving: bool = false
-var total_seconds_left: int = 0
-var total_seconds: int = 0
-var is_zoomed_in: bool = false
+var _input_time: int = 0
+var _is_microwaving: bool = false
+var _total_seconds_left: int = 0
+var _total_seconds: int = 0
+var _is_zoomed_in: bool = false
 
 
 func _ready() -> void:
@@ -17,8 +17,8 @@ func _ready() -> void:
 		button.mouse_filter = Control.MOUSE_FILTER_IGNORE
 
 func _input(event: InputEvent) -> void:
-	if is_zoomed_in and event.is_action_pressed("ExitCameraZoom"):
-		is_zoomed_in = false
+	if _is_zoomed_in and event.is_action_pressed("ExitCameraZoom"):
+		_is_zoomed_in = false
 
 		# Buttons can't be clicked on if zoomed out.
 		for button: TextureButton in $Keypad.get_children():
@@ -36,29 +36,29 @@ func find_container(interactor: PhysicsBody2D) -> ContainerComponent:
 func _on_keypad_button_pressed(button_value: String) -> void:
 	match button_value:
 		"Clear":
-			input_time = 0
+			_input_time = 0
 			$TimerLabel.text = "0:00"
 		"Start":
 			_on_start_button_pressed()
 
 		_:
-			if str(input_time).length() >= 4: # Keep it 4 digits max
+			if str(_input_time).length() >= 4: # Keep it 4 digits max
 				return
 
-			input_time = (input_time * 10 + int(button_value))
+			_input_time = (_input_time * 10 + int(button_value))
 
 			# If the user input is 300, it should be in the form 3:00
-			var minutes: int = input_time / 100
-			var seconds: int = input_time % 100
+			var minutes: int = _input_time / 100
+			var seconds: int = _input_time % 100
 
-			total_seconds_left = minutes * 60 + seconds
-			total_seconds = total_seconds_left
+			_total_seconds_left = minutes * 60 + seconds
+			_total_seconds = _total_seconds_left
 			update_timer_display(minutes, seconds)
 
 ## Handles when the area is clicked on. If so zoom in on the microwave
 func _on_keypad_area_input_event(_viewport: Node, event: InputEvent, _shape_idx: int) -> void:
-	if event.is_action_pressed("click") and not is_zoomed_in:
-		is_zoomed_in = true
+	if event.is_action_pressed("click") and not _is_zoomed_in:
+		_is_zoomed_in = true
 		TransitionCamera.target_camera = $ZoomCamera
 
 		# Keypad buttons should be clickable if zoomed in on
@@ -69,21 +69,21 @@ func _on_keypad_area_input_event(_viewport: Node, event: InputEvent, _shape_idx:
 func _on_start_button_pressed() -> void:
 	var obj: LabBody = $ObjectContainmentInteractableArea.contained_object
 
-	if obj and not is_microwaving:
-		is_microwaving = true
+	if obj and not _is_microwaving:
+		_is_microwaving = true
 
 		$MicrowaveTimer.start()
 		print("Heating %s" % [obj.name])
 	elif not obj:
 		print("Theres nothing in the Microwave!")
-	elif is_microwaving:
+	elif _is_microwaving:
 		print("Something is currently being microwaved!")
 
 ## Triggered either by the "stop" button or the timer ran out
 func _on_microwave_stopped() -> void:
-	if is_microwaving:
+	if _is_microwaving:
 		$MicrowaveTimer.stop()
-		is_microwaving = false
+		_is_microwaving = false
 
 		var obj: LabBody = $ObjectContainmentInteractableArea.contained_object
 		if obj:
@@ -94,12 +94,12 @@ func _on_microwave_stopped() -> void:
 				#
 				# This is very approximately equal to the amount of heating you would get if the
 				# container were full of only water.
-				var temp_increase: float = 160.0 * (total_seconds - total_seconds_left) \
+				var temp_increase: float = 160.0 * (_total_seconds - _total_seconds_left) \
 					/ container_to_heat.get_total_volume()
 				container_to_heat.temperature += temp_increase
 
-		# Update total_seconds for the next "start" press if the user doesn't clear
-		total_seconds = total_seconds_left
+		# Update _total_seconds for the next "start" press if the user doesn't clear
+		_total_seconds = _total_seconds_left
 
 	$ObjectContainmentInteractableArea.remove_object()
 
@@ -108,12 +108,12 @@ func update_timer_display(minutes: int, seconds: int) -> void:
 
 ## Updates the TimerLabel to countdown the timer
 func _on_microwave_timer_timeout() -> void:
-	if total_seconds_left > 0:
-		total_seconds_left -= 1
-		input_time -= 1
+	if _total_seconds_left > 0:
+		_total_seconds_left -= 1
+		_input_time -= 1
 		# Convert seconds to minutes and seconds
-		var minutes: int = total_seconds_left / 60
-		var seconds: int = total_seconds_left % 60
+		var minutes: int = _total_seconds_left / 60
+		var seconds: int = _total_seconds_left % 60
 
 		update_timer_display(minutes, seconds)
 

--- a/project/source/combined_scripts/microwave.gd.uid
+++ b/project/source/combined_scripts/microwave.gd.uid
@@ -1,0 +1,1 @@
+uid://b10fibv688ggy

--- a/project/source/combined_scripts/microwave_interactable_area.gd.uid
+++ b/project/source/combined_scripts/microwave_interactable_area.gd.uid
@@ -1,1 +1,0 @@
-uid://kyg3yiaw5rp2

--- a/project/source/combined_scripts/object_containment_interactable_area.gd
+++ b/project/source/combined_scripts/object_containment_interactable_area.gd
@@ -1,0 +1,43 @@
+class_name ObjectContainmentInteractableArea
+extends ObjectSlotInteractableArea
+## An object slot that fully contains an object (rather than just attaching it, like
+## `AttachmentInteractableArea`). This is done by making the object invisible and its drag component
+## uninteractable. There is no way to remove the object except by directly calling the
+## `remove_object` function.
+
+
+## This will be outlined when an object is (possibly) about to be inserted.
+@export var selectable_canvas_group: SelectableCanvasGroup
+
+## See `object_slot_interactable_area.gd` for an expalantion.
+@export var allow_all_bodies: bool = false
+## See `object_slot_interactable_area.gd` for an expalantion.
+@export var allowed_body_groups: Array[StringName] = []
+
+
+# Drag component of the contained object. Used to enable and disable interaction with it.
+var _drag_component: DragComponent = null
+
+
+func start_targeting(_k: InteractInfo.Kind) -> void:
+	if selectable_canvas_group: selectable_canvas_group.is_outlined = true
+
+func stop_targeting(_k: InteractInfo.Kind) -> void:
+	if selectable_canvas_group: selectable_canvas_group.is_outlined = false
+
+func can_place(body: LabBody) -> bool:
+	return allow_all_bodies or allowed_body_groups.any(func(g: StringName) -> bool: return body.is_in_group(g))
+
+func on_place_object() -> void:
+	_drag_component = Interaction.active_drag_component
+	if _drag_component:
+		_drag_component.stop_dragging()
+		_drag_component.enable_interaction = false
+
+	contained_object.hide()
+	contained_object.start_dragging()
+
+func on_remove_object() -> void:
+	contained_object.show()
+	contained_object.stop_dragging()
+	_drag_component.enable_interaction = true

--- a/project/source/combined_scripts/object_containment_interactable_area.gd.uid
+++ b/project/source/combined_scripts/object_containment_interactable_area.gd.uid
@@ -1,0 +1,1 @@
+uid://b3sgxo0w05r88

--- a/project/source/combined_scripts/object_slot_interactable_area.gd
+++ b/project/source/combined_scripts/object_slot_interactable_area.gd
@@ -1,0 +1,58 @@
+class_name ObjectSlotInteractableArea
+extends InteractableArea
+## An interactable area that allows objects to be placed. The object doesn't actually get affected
+## when it's placed, but it's possible to add behavior for that in classes deriving from
+## `ObjectSlotInteractableArea`.
+
+
+signal object_placed(body: LabBody)
+signal object_removed(body: LabBody)
+
+
+@export var contained_object: LabBody = null
+@export var place_prompt: String = "Place"
+
+
+func get_interactions() -> Array[InteractInfo]:
+	if not contained_object and can_place(Interaction.active_drag_component.body):
+		return [InteractInfo.new(InteractInfo.Kind.PRIMARY, place_prompt)]
+	else:
+		return []
+
+func start_interact(_k: InteractInfo.Kind) -> void:
+	_place_object_unchecked(Interaction.active_drag_component.body)
+
+## (virtual) determine whether the given object can be placed in this slot. The object will be
+## placed only if this function returns true and there is not already a contained object.
+func can_place(_body: LabBody) -> bool: return false
+
+## (virtual) called when an object is placed. `contained_object` will always be set before this is
+## called.
+func on_place_object() -> void: pass
+
+## (virtual) called when an object is removed. `contained_object` is set to null only *after* this
+## function returns, so it can be accessed there.
+func on_remove_object() -> void: pass
+
+## Call this to attempt to place an object. Returns true if the object was placed.
+func place_object(body: LabBody) -> bool:
+	if not contained_object and can_place(Interaction.active_drag_component.body):
+		_place_object_unchecked(body)
+		return true
+
+	return false
+
+## Call this to remove the current object, if it is there. Returns true if an object was removed.
+func remove_object() -> bool:
+	if contained_object:
+		on_remove_object()
+		object_removed.emit(contained_object)
+		contained_object = null
+		return true
+
+	return false
+
+func _place_object_unchecked(body: LabBody) -> void:
+	contained_object = body
+	on_place_object()
+	object_placed.emit(body)

--- a/project/source/combined_scripts/object_slot_interactable_area.gd
+++ b/project/source/combined_scripts/object_slot_interactable_area.gd
@@ -13,6 +13,18 @@ signal object_removed(body: LabBody)
 @export var place_prompt: String = "Place"
 
 
+func _ready() -> void:
+	super()
+
+	# The contained object may be set such that the simulation starts with the object locked in. In
+	# that case, we have to manually place it. We have to set `contained_object` to null first,
+	# however, since `place_object` expects that there be no contained object.
+	if contained_object:
+		var obj := contained_object
+		contained_object = null
+		if not place_object(obj):
+			print("Warning: failed to put object %s in slot %s" % [obj, self])
+
 func get_interactions() -> Array[InteractInfo]:
 	if not contained_object and can_place(Interaction.active_drag_component.body):
 		return [InteractInfo.new(InteractInfo.Kind.PRIMARY, place_prompt)]
@@ -36,7 +48,7 @@ func on_remove_object() -> void: pass
 
 ## Call this to attempt to place an object. Returns true if the object was placed.
 func place_object(body: LabBody) -> bool:
-	if not contained_object and can_place(Interaction.active_drag_component.body):
+	if not contained_object and can_place(body):
 		_place_object_unchecked(body)
 		return true
 

--- a/project/source/combined_scripts/object_slot_interactable_area.gd.uid
+++ b/project/source/combined_scripts/object_slot_interactable_area.gd.uid
@@ -1,0 +1,1 @@
+uid://dwo0o6nklmvbm

--- a/project/source/combined_scripts/util.gd
+++ b/project/source/combined_scripts/util.gd
@@ -32,6 +32,29 @@ static func make_sprite_ghost(node: Node2D) -> Node2D:
 
 	return root
 
+# Get a bounding box for the full collision of a `CollisionObject2D`. This can be used, for
+# example, to automatically find where the "bottom" of an object is.
+#
+# TODO: This might not be 100% accurate, since it fails to take into account transforms of
+# `CollisionShape2D`s.
+static func get_bounding_box(obj: CollisionObject2D) -> Rect2:
+	var shapes: Array[CollisionShape2D] = []
+	shapes.assign(
+		obj.find_children("", "CollisionShape2D", false)
+			.filter(func(s: CollisionShape2D) -> bool: return s.shape != null))
+
+	var rect := Rect2()
+	var first := true
+	for s: CollisionShape2D in obj.find_children("", "CollisionShape2D", false):
+		if s.shape:
+			if first:
+				rect = s.shape.get_rect()
+				first = false
+			else:
+				rect = rect.merge(s.shape.get_rect())
+
+	return rect
+
 static func _make_sprite_ghost_impl(node: Node2D) -> Node2D:
 	var new_node: Node2D = null
 	if node is Sprite2D:

--- a/project/source/combined_scripts/util.gd
+++ b/project/source/combined_scripts/util.gd
@@ -34,24 +34,18 @@ static func make_sprite_ghost(node: Node2D) -> Node2D:
 
 # Get a bounding box for the full collision of a `CollisionObject2D`. This can be used, for
 # example, to automatically find where the "bottom" of an object is.
-#
-# TODO: This might not be 100% accurate, since it fails to take into account transforms of
-# `CollisionShape2D`s.
 static func get_bounding_box(obj: CollisionObject2D) -> Rect2:
-	var shapes: Array[CollisionShape2D] = []
-	shapes.assign(
-		obj.find_children("", "CollisionShape2D", false)
-			.filter(func(s: CollisionShape2D) -> bool: return s.shape != null))
-
 	var rect := Rect2()
 	var first := true
-	for s: CollisionShape2D in obj.find_children("", "CollisionShape2D", false):
-		if s.shape:
+	for o in obj.get_shape_owners():
+		var transform: Transform2D = obj.shape_owner_get_transform(o)
+		for i in range(0, obj.shape_owner_get_shape_count(o)):
+			var s := obj.shape_owner_get_shape(o, i)
 			if first:
-				rect = s.shape.get_rect()
+				rect = transform * s.get_rect()
 				first = false
 			else:
-				rect = rect.merge(s.shape.get_rect())
+				rect = rect.merge(transform * s.get_rect())
 
 	return rect
 

--- a/project/source/project.godot
+++ b/project/source/project.godot
@@ -37,6 +37,7 @@ window/stretch/aspect="ignore"
 
 Emptyable=""
 attachment:microcentrifuge_tube=""
+attachment:scoopula=""
 
 [gui]
 

--- a/project/source/project.godot
+++ b/project/source/project.godot
@@ -36,6 +36,7 @@ window/stretch/aspect="ignore"
 [global_group]
 
 Emptyable=""
+attachment:microcentrifuge_tube=""
 
 [gui]
 

--- a/project/source/shaders/ghost.gdshader
+++ b/project/source/shaders/ghost.gdshader
@@ -9,7 +9,7 @@ void fragment()
 	vec4 c = textureLod(screen_texture, SCREEN_UV, 0.0);
 
 	// Basic pulsating effect.
-	c.a *= (cos(TIME * 5.0) + 1.0) / 4.0;
+	c *= mix(0.3, 0.6, (cos(TIME * 5.0) + 1.0) / 4.0);
 
 	// For `CanvasGroup`.
 	if (c.a > 0.0001)

--- a/project/source/shaders/ghost.gdshader
+++ b/project/source/shaders/ghost.gdshader
@@ -1,0 +1,21 @@
+// Used to show a "ghost" version of an object where it will be placed.
+shader_type canvas_item;
+render_mode unshaded;
+
+uniform sampler2D screen_texture : hint_screen_texture, repeat_disable, filter_nearest;
+
+void fragment()
+{
+	vec4 c = textureLod(screen_texture, SCREEN_UV, 0.0);
+
+	// Basic pulsating effect.
+	c.a *= (cos(TIME * 5.0) + 1.0) / 4.0;
+
+	// For `CanvasGroup`.
+	if (c.a > 0.0001)
+	{
+		c.rgb /= c.a;
+	}
+
+	COLOR *= c;
+}

--- a/project/source/shaders/ghost.gdshader.uid
+++ b/project/source/shaders/ghost.gdshader.uid
@@ -1,0 +1,1 @@
+uid://c136i7bij6rm2


### PR DESCRIPTION
Resolves #373

This PR adds three main node types:
- `ObjectSlotInteractableArea` is a generic interactable area that can have a single object slotted into it. It is possible to override functions for determining whether an object is allowed to be attached and what happens when the object is attached or removed, but by default, they don't do anything.
- `AttachmentInteractableArea` derives from `ObjectSlotInteractableArea` and allows an object to be "attached" to it. By default, the bottom middle of the object's hitbox will be locked to the position of the `AttachmentInteractableArea` node, but it is possible to change this by putting an `AttachmentPoint` on the object. `AttachmentInteractableArea` can be set to only allow objects or attachment points in certain groups. When the user is hovering the area with an object that can be placed, a ghost version of the object will appear where it would be placed.
- `ObjectContainmentInteractableArea` derives from `ObjectSlotInteractableArea` and will hide the object instead of attaching it. This also allows filtering based on groups.

These names aren't very good, so if anyone has any better name ideas, then I would love to hear them. The current way of filtering objects is kind of inflexible, since there are times where we might want to filter by type or by whether something is a container, for example.

I've also made the following changes:
- Fixed a few bugs with the `DragComponent` outlining that were made especially apparent by the attachment system.
- Updated the microwave to use an `ObjectContainmentInteractableArea` and moved most of the code into a script `microwave.gd` in the root node. To simplify it a bit, I've made it so that the microwave will allow *any* object to be placed in it, even if it doesn't have a `ContainerComponent`. I can change this if needed.
- Added `AttachmentInteractableArea`s to the scoopula and microcentrifuge tube holders so they can actually be attached. This should also be used for the pipette holder when it's added.

Currently, placing objects into the holders causes them to be on top of the holder sprite, which is incorrect. We need to have a more sophisticated z-index system for this to work correctly.