### PR TITLE
Added Contact Wires and Time and Voltage to Power Supply

### DIFF
--- a/project/source/Scenes/Boundaries/LabBoundary.tscn
+++ b/project/source/Scenes/Boundaries/LabBoundary.tscn
@@ -1,6 +1,6 @@
 [gd_scene load_steps=3 format=3 uid="uid://dhx7svmclbqm6"]
 
-[ext_resource type="Script" uid="uid://dw0jk61dnhedo" path="res://Scripts/Boundaries/LabBoundary.gd" id="1"]
+[ext_resource type="Script" uid="uid://lurd144vb67m" path="res://Scripts/Boundaries/LabBoundary.gd" id="1"]
 
 [sub_resource type="RectangleShape2D" id="1"]
 

--- a/project/source/Scenes/Modules/combined.tscn
+++ b/project/source/Scenes/Modules/combined.tscn
@@ -161,21 +161,17 @@ script = ExtResource("21_kobiv")
 
 [node name="RedContactWire" parent="ContactWires" instance=ExtResource("21_gvdu8")]
 position = Vector2(686, 455)
-collision_layer = 2
 
 [node name="RedContactWire2" parent="ContactWires" instance=ExtResource("21_gvdu8")]
 position = Vector2(718, 455)
-collision_layer = 2
 
 [node name="BlackContactWire" parent="ContactWires" instance=ExtResource("21_gvdu8")]
 position = Vector2(686, 479)
-collision_layer = 2
 texture = ExtResource("22_kobiv")
 charge = 1
 
 [node name="BlackContactWire2" parent="ContactWires" instance=ExtResource("21_gvdu8")]
 position = Vector2(718, 479)
-collision_layer = 2
 texture = ExtResource("22_kobiv")
 charge = 1
 

--- a/project/source/Scenes/Modules/combined.tscn
+++ b/project/source/Scenes/Modules/combined.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=23 format=3 uid="uid://bnn7yyuvh6jsj"]
+[gd_scene load_steps=26 format=3 uid="uid://bnn7yyuvh6jsj"]
 
 [ext_resource type="Texture2D" uid="uid://csifb4mbnybmu" path="res://updated_assets/background.png" id="1_1qt3r"]
 [ext_resource type="PackedScene" uid="uid://b5ff3gy87ykja" path="res://combined_scenes/flask.tscn" id="2_e4xug"]
@@ -20,6 +20,9 @@
 [ext_resource type="PackedScene" uid="uid://dqc2dtt648v3m" path="res://combined_scenes/biohazard_bin.tscn" id="17_6se67"]
 [ext_resource type="Script" uid="uid://b8kjtd0vdnq42" path="res://combined_scripts/transition_camera.gd" id="18_1qt3r"]
 [ext_resource type="PackedScene" uid="uid://bt321lhs647bu" path="res://combined_scenes/microcentrifuge_holder.tscn" id="18_xe06v"]
+[ext_resource type="PackedScene" uid="uid://cxmqgu76dc3v" path="res://combined_scenes/contact_wire.tscn" id="21_gvdu8"]
+[ext_resource type="Script" uid="uid://qijnhs2e78qy" path="res://combined_scripts/contact_wires.gd" id="21_kobiv"]
+[ext_resource type="Texture2D" uid="uid://dwb7gsbcv24kv" path="res://updated_assets/icons_and_buttons/contact_negative.svg" id="22_kobiv"]
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_5wocf"]
 size = Vector2(1430, 222)
@@ -152,6 +155,29 @@ position = Vector2(641, 360)
 offset = Vector2(0.78, 0)
 script = ExtResource("18_1qt3r")
 main_scene_camera = NodePath("../MainSceneCamera")
+
+[node name="ContactWires" type="Node2D" parent="."]
+script = ExtResource("21_kobiv")
+
+[node name="RedContactWire" parent="ContactWires" instance=ExtResource("21_gvdu8")]
+position = Vector2(686, 455)
+collision_layer = 2
+
+[node name="RedContactWire2" parent="ContactWires" instance=ExtResource("21_gvdu8")]
+position = Vector2(718, 455)
+collision_layer = 2
+
+[node name="BlackContactWire" parent="ContactWires" instance=ExtResource("21_gvdu8")]
+position = Vector2(686, 479)
+collision_layer = 2
+texture = ExtResource("22_kobiv")
+charge = 1
+
+[node name="BlackContactWire2" parent="ContactWires" instance=ExtResource("21_gvdu8")]
+position = Vector2(718, 479)
+collision_layer = 2
+texture = ExtResource("22_kobiv")
+charge = 1
 
 [editable path="ScoopulaHolder"]
 [editable path="MicrocentrifugeHolder"]

--- a/project/source/combined_scenes/contact_wire.tscn
+++ b/project/source/combined_scenes/contact_wire.tscn
@@ -1,0 +1,48 @@
+[gd_scene load_steps=8 format=3 uid="uid://cxmqgu76dc3v"]
+
+[ext_resource type="Script" uid="uid://bstdxu8mmw8e6" path="res://combined_scripts/contact_wire.gd" id="1_py2n2"]
+[ext_resource type="Texture2D" uid="uid://c8bk01l556mhm" path="res://updated_assets/icons_and_buttons/contact_positive.svg" id="2_4eh70"]
+[ext_resource type="Script" uid="uid://p0x2f70nn1sy" path="res://combined_scripts/selectable_canvas_group.gd" id="3_6tvr8"]
+[ext_resource type="Script" uid="uid://bsonh03rfuf2p" path="res://combined_scripts/drag_component.gd" id="4_clbnk"]
+[ext_resource type="Script" uid="uid://8jbti40eodk6" path="res://combined_scripts/interactable_area.gd" id="5_8mduc"]
+[ext_resource type="Script" uid="uid://cvvkvehovfwuy" path="res://combined_scripts/attachment_point.gd" id="6_4eh70"]
+
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_05efo"]
+size = Vector2(12, 14)
+
+[node name="ContactWire" type="RigidBody2D" groups=["contact_wire"]]
+collision_layer = 2
+freeze = true
+freeze_mode = 1
+script = ExtResource("1_py2n2")
+texture = ExtResource("2_4eh70")
+metadata/_custom_type_script = "uid://b4dann3kdfg3k"
+
+[node name="SelectableCanvasGroup" type="CanvasGroup" parent="."]
+script = ExtResource("3_6tvr8")
+metadata/_custom_type_script = "uid://p0x2f70nn1sy"
+
+[node name="Sprite2D" type="Sprite2D" parent="SelectableCanvasGroup"]
+scale = Vector2(0.02, 0.02)
+texture = ExtResource("2_4eh70")
+
+[node name="DragComponent" type="Node2D" parent="." node_paths=PackedStringArray("body", "interact_canvas_group")]
+script = ExtResource("4_clbnk")
+body = NodePath("..")
+interact_canvas_group = NodePath("../SelectableCanvasGroup")
+metadata/_custom_type_script = "uid://bsonh03rfuf2p"
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="."]
+shape = SubResource("RectangleShape2D_05efo")
+
+[node name="InteractableArea" type="Area2D" parent="."]
+script = ExtResource("5_8mduc")
+metadata/_custom_type_script = "uid://8jbti40eodk6"
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="InteractableArea"]
+shape = SubResource("RectangleShape2D_05efo")
+
+[node name="AttachmentPoint" type="Node2D" parent="." groups=["attachment:contact_wire"]]
+position = Vector2(0, 1)
+script = ExtResource("6_4eh70")
+metadata/_custom_type_script = "uid://cvvkvehovfwuy"

--- a/project/source/combined_scenes/flask.tscn
+++ b/project/source/combined_scenes/flask.tscn
@@ -7,7 +7,7 @@
 [ext_resource type="Script" uid="uid://b0ywjj7uwvbji" path="res://combined_scripts/substance_display_polygon.gd" id="3_lx5v4"]
 [ext_resource type="Texture2D" uid="uid://c5pkfaov7ufug" path="res://updated_assets/lab_objects/erlenmeyer_flask.svg" id="5_6iauc"]
 
-[node name="Flask" type="RigidBody2D" groups=["Emptyable"]]
+[node name="Flask" type="RigidBody2D" groups=["emptyable"]]
 collision_layer = 0
 script = ExtResource("1_6iauc")
 metadata/_custom_type_script = "uid://b4dann3kdfg3k"

--- a/project/source/combined_scenes/graduated_cylinder.tscn
+++ b/project/source/combined_scenes/graduated_cylinder.tscn
@@ -10,7 +10,7 @@
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_ufkpi"]
 size = Vector2(26, 171)
 
-[node name="GraduatedCylinder" type="RigidBody2D" groups=["Emptyable"]]
+[node name="GraduatedCylinder" type="RigidBody2D" groups=["emptyable"]]
 collision_layer = 0
 script = ExtResource("1_5k7v7")
 metadata/_custom_type_script = "uid://b4dann3kdfg3k"

--- a/project/source/combined_scenes/power_supply.tscn
+++ b/project/source/combined_scenes/power_supply.tscn
@@ -1,14 +1,21 @@
-[gd_scene load_steps=10 format=3 uid="uid://b4q3npoc5c7fy"]
+[gd_scene load_steps=11 format=3 uid="uid://b4q3npoc5c7fy"]
 
-[ext_resource type="Script" uid="uid://b4dann3kdfg3k" path="res://combined_scripts/lab_body.gd" id="1_7lagc"]
+[ext_resource type="Script" uid="uid://bepsdcjab3t21" path="res://combined_scripts/power_supply.gd" id="1_7lagc"]
 [ext_resource type="Script" uid="uid://p0x2f70nn1sy" path="res://combined_scripts/selectable_canvas_group.gd" id="1_80iu8"]
 [ext_resource type="Script" uid="uid://bsonh03rfuf2p" path="res://combined_scripts/drag_component.gd" id="3_3yhad"]
-[ext_resource type="Texture2D" uid="uid://bi5tvuv5gh5u" path="res://UpdatedAssets/LabObjects/Powerbox.svg" id="3_7lagc"]
-[ext_resource type="Texture2D" uid="uid://crtq0m4w5xpmy" path="res://UpdatedAssets/IconsAndButtons/Plus_Symbol.svg" id="7_5dnns"]
-[ext_resource type="Texture2D" uid="uid://spcel0l2t7ec" path="res://UpdatedAssets/IconsAndButtons/Minus_Symbol.svg" id="8_07yqv"]
+[ext_resource type="Texture2D" uid="uid://bi5tvuv5gh5u" path="res://updated_assets/lab_objects/powerbox.svg" id="3_7lagc"]
+[ext_resource type="Texture2D" uid="uid://crtq0m4w5xpmy" path="res://updated_assets/icons_and_buttons/plus_symbol.svg" id="7_5dnns"]
+[ext_resource type="Script" uid="uid://brj1u83e5o6i6" path="res://combined_scripts/attachment_power_supply_outlet.gd" id="7_07yqv"]
+[ext_resource type="Texture2D" uid="uid://spcel0l2t7ec" path="res://updated_assets/icons_and_buttons/minus_symbol.svg" id="8_07yqv"]
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_80iu8"]
 size = Vector2(98, 38)
+
+[sub_resource type="CircleShape2D" id="CircleShape2D_k6dxr"]
+radius = 7.0
+
+[sub_resource type="CircleShape2D" id="CircleShape2D_7lagc"]
+radius = 7.0
 
 [node name="PowerSupply" type="RigidBody2D"]
 collision_layer = 0
@@ -60,3 +67,33 @@ texture = ExtResource("7_5dnns")
 position = Vector2(-36, 4)
 scale = Vector2(0.016, 0.016)
 texture = ExtResource("8_07yqv")
+
+[node name="AttachmentPostiveOutlet" type="Area2D" parent="."]
+position = Vector2(-36, -11)
+script = ExtResource("7_07yqv")
+allowed_point_groups = Array[StringName]([&"attachment:contact_wire"])
+metadata/_custom_type_script = "uid://ul3h2acp7c3y"
+metadata/_edit_group_ = true
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="AttachmentPostiveOutlet"]
+shape = SubResource("CircleShape2D_k6dxr")
+debug_color = Color(0.960415, 0, 0.51616, 0.42)
+
+[node name="AttachmentNegativeOutlet" type="Area2D" parent="."]
+position = Vector2(-36, 5)
+script = ExtResource("7_07yqv")
+expected_outlet_charge = 1
+allowed_point_groups = Array[StringName]([&"attachment:contact_wire"])
+metadata/_custom_type_script = "uid://ul3h2acp7c3y"
+metadata/_edit_group_ = true
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="AttachmentNegativeOutlet"]
+shape = SubResource("CircleShape2D_7lagc")
+debug_color = Color(0.799247, 0.420694, 0.0500949, 0.42)
+
+[connection signal="object_placed" from="AttachmentPostiveOutlet" to="AttachmentPostiveOutlet" method="_on_object_placed"]
+[connection signal="object_removed" from="AttachmentPostiveOutlet" to="." method="unplug_handler"]
+[connection signal="wire_connected" from="AttachmentPostiveOutlet" to="." method="_on_wire_connected"]
+[connection signal="object_placed" from="AttachmentNegativeOutlet" to="AttachmentNegativeOutlet" method="_on_object_placed"]
+[connection signal="object_removed" from="AttachmentNegativeOutlet" to="." method="unplug_handler"]
+[connection signal="wire_connected" from="AttachmentNegativeOutlet" to="." method="_on_wire_connected"]

--- a/project/source/combined_scenes/power_supply.tscn
+++ b/project/source/combined_scenes/power_supply.tscn
@@ -68,10 +68,11 @@ position = Vector2(-36, 4)
 scale = Vector2(0.016, 0.016)
 texture = ExtResource("8_07yqv")
 
-[node name="AttachmentPostiveOutlet" type="Area2D" parent="."]
+[node name="AttachmentPostiveOutlet" type="Area2D" parent="." node_paths=PackedStringArray("selectable_canvas_group")]
 position = Vector2(-36, -11)
 script = ExtResource("7_07yqv")
-allowed_point_groups = Array[StringName]([&"attachment:contact_wire"])
+selectable_canvas_group = NodePath("../SelectableCanvasGroup")
+point_groups = Array[StringName]([&"attachment:contact_wire"])
 metadata/_custom_type_script = "uid://ul3h2acp7c3y"
 metadata/_edit_group_ = true
 
@@ -79,11 +80,12 @@ metadata/_edit_group_ = true
 shape = SubResource("CircleShape2D_k6dxr")
 debug_color = Color(0.960415, 0, 0.51616, 0.42)
 
-[node name="AttachmentNegativeOutlet" type="Area2D" parent="."]
+[node name="AttachmentNegativeOutlet" type="Area2D" parent="." node_paths=PackedStringArray("selectable_canvas_group")]
 position = Vector2(-36, 5)
 script = ExtResource("7_07yqv")
 outlet_charge = 1
-allowed_point_groups = Array[StringName]([&"attachment:contact_wire"])
+selectable_canvas_group = NodePath("../SelectableCanvasGroup")
+point_groups = Array[StringName]([&"attachment:contact_wire"])
 metadata/_custom_type_script = "uid://ul3h2acp7c3y"
 metadata/_edit_group_ = true
 

--- a/project/source/combined_scenes/power_supply.tscn
+++ b/project/source/combined_scenes/power_supply.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=11 format=3 uid="uid://b4q3npoc5c7fy"]
+[gd_scene load_steps=15 format=3 uid="uid://b4q3npoc5c7fy"]
 
 [ext_resource type="Script" uid="uid://bepsdcjab3t21" path="res://combined_scripts/power_supply.gd" id="1_7lagc"]
 [ext_resource type="Script" uid="uid://p0x2f70nn1sy" path="res://combined_scripts/selectable_canvas_group.gd" id="1_80iu8"]
@@ -6,6 +6,7 @@
 [ext_resource type="Texture2D" uid="uid://bi5tvuv5gh5u" path="res://updated_assets/lab_objects/powerbox.svg" id="3_7lagc"]
 [ext_resource type="Texture2D" uid="uid://crtq0m4w5xpmy" path="res://updated_assets/icons_and_buttons/plus_symbol.svg" id="7_5dnns"]
 [ext_resource type="Script" uid="uid://brj1u83e5o6i6" path="res://combined_scripts/attachment_power_supply_outlet.gd" id="7_07yqv"]
+[ext_resource type="Texture2D" uid="uid://bd4nu6l1dgnec" path="res://updated_assets/icons_and_buttons/button_2.svg" id="8_5dnns"]
 [ext_resource type="Texture2D" uid="uid://spcel0l2t7ec" path="res://updated_assets/icons_and_buttons/minus_symbol.svg" id="8_07yqv"]
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_80iu8"]
@@ -17,9 +18,48 @@ radius = 7.0
 [sub_resource type="CircleShape2D" id="CircleShape2D_7lagc"]
 radius = 7.0
 
-[node name="PowerSupply" type="RigidBody2D"]
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_46x6c"]
+size = Vector2(48, 20)
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_46x6c"]
+bg_color = Color(0.6, 0.6, 0.6, 0)
+border_width_left = 1
+border_width_top = 1
+border_width_right = 1
+border_width_bottom = 1
+border_color = Color(0.462745, 0.862745, 0.988235, 1)
+corner_radius_top_left = 1
+corner_radius_top_right = 1
+corner_radius_bottom_right = 1
+corner_radius_bottom_left = 1
+expand_margin_left = 2.0
+expand_margin_top = 2.0
+expand_margin_right = 2.0
+expand_margin_bottom = 2.0
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_5dnns"]
+bg_color = Color(0.6, 0.6, 0.6, 0)
+border_width_left = 1
+border_width_top = 1
+border_width_right = 1
+border_width_bottom = 1
+border_color = Color(0.462745, 0.862745, 0.988235, 1)
+corner_radius_top_left = 1
+corner_radius_top_right = 1
+corner_radius_bottom_right = 1
+corner_radius_bottom_left = 1
+expand_margin_left = 2.0
+expand_margin_top = 2.0
+expand_margin_right = 2.0
+expand_margin_bottom = 2.0
+
+[node name="PowerSupply" type="RigidBody2D" node_paths=PackedStringArray("increment_time_button", "decrement_time_button", "increment_volts_button", "decrement_volts_button")]
 collision_layer = 0
 script = ExtResource("1_7lagc")
+increment_time_button = NodePath("Screen/IncrementTime")
+decrement_time_button = NodePath("Screen/DecrementTime")
+increment_volts_button = NodePath("Screen/IncrementVolts")
+decrement_volts_button = NodePath("Screen/DecrementVolts")
 metadata/_custom_type_script = "uid://b4dann3kdfg3k"
 
 [node name="SelectableCanvasGroup" type="CanvasGroup" parent="."]
@@ -32,6 +72,7 @@ scale = Vector2(0.174763, 0.174763)
 texture = ExtResource("3_7lagc")
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
+visible = false
 position = Vector2(0, -2)
 shape = SubResource("RectangleShape2D_80iu8")
 
@@ -93,6 +134,198 @@ metadata/_edit_group_ = true
 shape = SubResource("CircleShape2D_7lagc")
 debug_color = Color(0.799247, 0.420694, 0.0500949, 0.42)
 
+[node name="ZoomCamera" type="Camera2D" parent="."]
+zoom = Vector2(4.5, 4.5)
+position_smoothing_speed = 20.0
+
+[node name="Screen" type="Area2D" parent="."]
+
+[node name="CollisionShape2D2" type="CollisionShape2D" parent="Screen"]
+position = Vector2(-2, -3)
+shape = SubResource("RectangleShape2D_46x6c")
+
+[node name="TimeContainer" type="PanelContainer" parent="Screen"]
+offset_left = -24.0
+offset_top = -11.0
+offset_right = 83.0
+offset_bottom = 10.0
+scale = Vector2(0.3, 0.3)
+mouse_filter = 2
+theme_override_styles/panel = SubResource("StyleBoxFlat_46x6c")
+metadata/_edit_group_ = true
+
+[node name="HBoxContainer" type="HBoxContainer" parent="Screen/TimeContainer"]
+layout_mode = 2
+mouse_filter = 2
+
+[node name="TimeString" type="Label" parent="Screen/TimeContainer/HBoxContainer"]
+layout_mode = 2
+size_flags_horizontal = 0
+theme_override_constants/outline_size = 0
+text = "Time:"
+
+[node name="Time" type="Label" parent="Screen/TimeContainer/HBoxContainer"]
+layout_mode = 2
+size_flags_horizontal = 10
+text = "0:00"
+
+[node name="VoltageContainer" type="PanelContainer" parent="Screen"]
+offset_left = -24.0
+offset_top = -2.0
+offset_right = 83.0
+offset_bottom = 19.0
+scale = Vector2(0.3, 0.3)
+mouse_filter = 2
+theme_override_styles/panel = SubResource("StyleBoxFlat_5dnns")
+metadata/_edit_group_ = true
+
+[node name="HBoxContainer" type="HBoxContainer" parent="Screen/VoltageContainer"]
+layout_mode = 2
+mouse_filter = 2
+
+[node name="VoltageString" type="Label" parent="Screen/VoltageContainer/HBoxContainer"]
+layout_mode = 2
+size_flags_horizontal = 0
+text = "Voltage:"
+
+[node name="Volts" type="Label" parent="Screen/VoltageContainer/HBoxContainer"]
+layout_mode = 2
+size_flags_horizontal = 10
+text = "0"
+
+[node name="VLabel" type="Label" parent="Screen/VoltageContainer/HBoxContainer"]
+layout_mode = 2
+size_flags_horizontal = 8
+text = "V"
+
+[node name="IncrementTime" type="TextureButton" parent="Screen"]
+self_modulate = Color(0.399986, 0.99514, 0.995763, 1)
+offset_left = 11.0
+offset_top = -13.0
+offset_right = 1035.0
+offset_bottom = 755.0
+scale = Vector2(0.00813575, 0.00813575)
+size_flags_horizontal = 4
+mouse_filter = 2
+mouse_default_cursor_shape = 2
+texture_normal = ExtResource("8_5dnns")
+metadata/_edit_group_ = true
+
+[node name="Label" type="Label" parent="Screen/IncrementTime"]
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -64.0
+offset_top = -176.0
+offset_right = 64.0
+offset_bottom = 286.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_font_sizes/font_size = 300
+text = "^"
+horizontal_alignment = 1
+vertical_alignment = 1
+
+[node name="DecrementTime" type="TextureButton" parent="Screen"]
+self_modulate = Color(0.399986, 0.99514, 0.995763, 1)
+offset_left = 11.0
+offset_top = -9.0
+offset_right = 1035.0
+offset_bottom = 759.0
+scale = Vector2(0.00813575, 0.00813575)
+size_flags_horizontal = 4
+mouse_filter = 2
+mouse_default_cursor_shape = 2
+texture_normal = ExtResource("8_5dnns")
+metadata/_edit_group_ = true
+
+[node name="Label" type="Label" parent="Screen/DecrementTime"]
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = 102.57
+offset_top = 230.57
+offset_right = 307.57
+offset_bottom = 761.57
+grow_horizontal = 2
+grow_vertical = 2
+rotation = 3.14159
+theme_override_font_sizes/font_size = 300
+text = "^"
+horizontal_alignment = 1
+vertical_alignment = 1
+
+[node name="IncrementVolts" type="TextureButton" parent="Screen"]
+self_modulate = Color(0.399986, 0.99514, 0.995763, 1)
+offset_left = 11.0
+offset_top = -4.0
+offset_right = 1035.0
+offset_bottom = 764.0
+scale = Vector2(0.00813575, 0.00813575)
+size_flags_horizontal = 4
+mouse_filter = 2
+mouse_default_cursor_shape = 2
+texture_normal = ExtResource("8_5dnns")
+metadata/_edit_group_ = true
+
+[node name="Label" type="Label" parent="Screen/IncrementVolts"]
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -64.0
+offset_top = -176.0
+offset_right = 64.0
+offset_bottom = 286.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_font_sizes/font_size = 300
+text = "^"
+horizontal_alignment = 1
+vertical_alignment = 1
+
+[node name="DecrementVolts" type="TextureButton" parent="Screen"]
+self_modulate = Color(0.399986, 0.99514, 0.995763, 1)
+offset_left = 11.0
+offset_right = 1035.0
+offset_bottom = 768.0
+scale = Vector2(0.00813575, 0.00813575)
+size_flags_horizontal = 4
+mouse_filter = 2
+mouse_default_cursor_shape = 2
+texture_normal = ExtResource("8_5dnns")
+metadata/_edit_group_ = true
+
+[node name="Label" type="Label" parent="Screen/DecrementVolts"]
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = 102.57
+offset_top = 230.57
+offset_right = 307.57
+offset_bottom = 761.57
+grow_horizontal = 2
+grow_vertical = 2
+rotation = 3.14159
+theme_override_font_sizes/font_size = 300
+text = "^"
+horizontal_alignment = 1
+vertical_alignment = 1
+
+[node name="Timer" type="Timer" parent="."]
+wait_time = 0.15
+
 [connection signal="pressed" from="StartButton" to="." method="_on_start_button_pressed"]
 [connection signal="object_placed" from="AttachmentPostiveOutlet" to="AttachmentPostiveOutlet" method="_on_object_placed"]
 [connection signal="object_removed" from="AttachmentPostiveOutlet" to="." method="unplug_handler"]
@@ -100,3 +333,7 @@ debug_color = Color(0.799247, 0.420694, 0.0500949, 0.42)
 [connection signal="object_placed" from="AttachmentNegativeOutlet" to="AttachmentNegativeOutlet" method="_on_object_placed"]
 [connection signal="object_removed" from="AttachmentNegativeOutlet" to="." method="unplug_handler"]
 [connection signal="wire_connected" from="AttachmentNegativeOutlet" to="." method="_on_wire_connected"]
+[connection signal="input_event" from="Screen" to="." method="_on_screen_input_event"]
+[connection signal="mouse_entered" from="Screen" to="." method="_on_screen_mouse_entered"]
+[connection signal="mouse_exited" from="Screen" to="." method="_on_screen_mouse_exited"]
+[connection signal="timeout" from="Timer" to="." method="_on_timer_timeout"]

--- a/project/source/combined_scenes/power_supply.tscn
+++ b/project/source/combined_scenes/power_supply.tscn
@@ -82,7 +82,7 @@ debug_color = Color(0.960415, 0, 0.51616, 0.42)
 [node name="AttachmentNegativeOutlet" type="Area2D" parent="."]
 position = Vector2(-36, 5)
 script = ExtResource("7_07yqv")
-expected_outlet_charge = 1
+outlet_charge = 1
 allowed_point_groups = Array[StringName]([&"attachment:contact_wire"])
 metadata/_custom_type_script = "uid://ul3h2acp7c3y"
 metadata/_edit_group_ = true
@@ -91,6 +91,7 @@ metadata/_edit_group_ = true
 shape = SubResource("CircleShape2D_7lagc")
 debug_color = Color(0.799247, 0.420694, 0.0500949, 0.42)
 
+[connection signal="pressed" from="StartButton" to="." method="_on_start_button_pressed"]
 [connection signal="object_placed" from="AttachmentPostiveOutlet" to="AttachmentPostiveOutlet" method="_on_object_placed"]
 [connection signal="object_removed" from="AttachmentPostiveOutlet" to="." method="unplug_handler"]
 [connection signal="wire_connected" from="AttachmentPostiveOutlet" to="." method="_on_wire_connected"]

--- a/project/source/combined_scenes/power_supply.tscn
+++ b/project/source/combined_scenes/power_supply.tscn
@@ -27,7 +27,7 @@ border_width_left = 1
 border_width_top = 1
 border_width_right = 1
 border_width_bottom = 1
-border_color = Color(0.462745, 0.862745, 0.988235, 1)
+border_color = Color(0, 0, 0, 1)
 corner_radius_top_left = 1
 corner_radius_top_right = 1
 corner_radius_bottom_right = 1
@@ -43,7 +43,7 @@ border_width_left = 1
 border_width_top = 1
 border_width_right = 1
 border_width_bottom = 1
-border_color = Color(0.462745, 0.862745, 0.988235, 1)
+border_color = Color(0, 0, 0, 1)
 corner_radius_top_left = 1
 corner_radius_top_right = 1
 corner_radius_bottom_right = 1
@@ -199,7 +199,7 @@ size_flags_horizontal = 8
 text = "V"
 
 [node name="IncrementTime" type="TextureButton" parent="Screen"]
-self_modulate = Color(0.399986, 0.99514, 0.995763, 1)
+self_modulate = Color(0.982343, 0.982342, 0.982342, 1)
 offset_left = 11.0
 offset_top = -13.0
 offset_right = 1035.0
@@ -230,7 +230,7 @@ horizontal_alignment = 1
 vertical_alignment = 1
 
 [node name="DecrementTime" type="TextureButton" parent="Screen"]
-self_modulate = Color(0.399986, 0.99514, 0.995763, 1)
+self_modulate = Color(0.980392, 0.980392, 0.980392, 1)
 offset_left = 11.0
 offset_top = -9.0
 offset_right = 1035.0
@@ -262,7 +262,7 @@ horizontal_alignment = 1
 vertical_alignment = 1
 
 [node name="IncrementVolts" type="TextureButton" parent="Screen"]
-self_modulate = Color(0.399986, 0.99514, 0.995763, 1)
+self_modulate = Color(0.980392, 0.980392, 0.980392, 1)
 offset_left = 11.0
 offset_top = -4.0
 offset_right = 1035.0
@@ -293,7 +293,7 @@ horizontal_alignment = 1
 vertical_alignment = 1
 
 [node name="DecrementVolts" type="TextureButton" parent="Screen"]
-self_modulate = Color(0.399986, 0.99514, 0.995763, 1)
+self_modulate = Color(0.980392, 0.980392, 0.980392, 1)
 offset_left = 11.0
 offset_right = 1035.0
 offset_bottom = 768.0

--- a/project/source/combined_scripts/attachment_power_supply_outlet.gd
+++ b/project/source/combined_scripts/attachment_power_supply_outlet.gd
@@ -1,0 +1,29 @@
+extends AttachmentInteractableArea
+
+@export var expected_outlet_charge: Wire.Charge
+
+## Emits a signal carrying the wire and the outlet's charge that wire was trying to interact with
+signal wire_connected(wire: Wire, expected_outlet_charge: Wire.Charge)
+
+var interacting_wire: Wire
+
+func get_interactions() -> Array[InteractInfo]:
+	var info: InteractInfo
+	if can_place(Interaction.active_drag_component.body) and not contained_object:
+		info = InteractInfo.new(InteractInfo.Kind.PRIMARY, "Connect Wire")
+		return [info]
+
+	return []
+
+func start_interact(_k: InteractInfo.Kind) -> void:
+	super(_k)
+	if contained_object:
+		print("A wire is already plugged in!")
+	
+
+func can_place(body: LabBody) -> bool:
+	return body.is_in_group("contact_wire")
+
+func _on_object_placed(body: LabBody) -> void:
+	interacting_wire = body
+	wire_connected.emit(contained_object, expected_outlet_charge)

--- a/project/source/combined_scripts/attachment_power_supply_outlet.gd
+++ b/project/source/combined_scripts/attachment_power_supply_outlet.gd
@@ -1,29 +1,33 @@
 extends AttachmentInteractableArea
 
-@export var expected_outlet_charge: Wire.Charge
+@export var outlet_charge: Wire.Charge
 
 ## Emits a signal carrying the wire and the outlet's charge that wire was trying to interact with
-signal wire_connected(wire: Wire, expected_outlet_charge: Wire.Charge)
+signal wire_connected(wire: Wire, outlet_charge: Wire.Charge)
 
-var interacting_wire: Wire
+var interacting_wire: DragComponent
 
 func get_interactions() -> Array[InteractInfo]:
 	var info: InteractInfo
-	if can_place(Interaction.active_drag_component.body) and not contained_object:
+	if can_place(Interaction.active_drag_component.body):
+		interacting_wire = Interaction.active_drag_component
 		info = InteractInfo.new(InteractInfo.Kind.PRIMARY, "Connect Wire")
 		return [info]
 
 	return []
 
 func start_interact(_k: InteractInfo.Kind) -> void:
-	super(_k)
 	if contained_object:
-		print("A wire is already plugged in!")
-	
+		print("A wire is already connected to the %s outlet!" % [Wire.Charge.keys()[outlet_charge]])
+		interacting_wire.stop_dragging()
+		interacting_wire.body.position.y -= 50
+		return
+		
+	super(_k)
+		
 
 func can_place(body: LabBody) -> bool:
 	return body.is_in_group("contact_wire")
 
-func _on_object_placed(body: LabBody) -> void:
-	interacting_wire = body
-	wire_connected.emit(contained_object, expected_outlet_charge)
+func _on_object_placed(_body: LabBody) -> void:
+	wire_connected.emit(contained_object, outlet_charge)

--- a/project/source/combined_scripts/attachment_power_supply_outlet.gd.uid
+++ b/project/source/combined_scripts/attachment_power_supply_outlet.gd.uid
@@ -1,0 +1,1 @@
+uid://brj1u83e5o6i6

--- a/project/source/combined_scripts/contact_wire.gd
+++ b/project/source/combined_scripts/contact_wire.gd
@@ -1,0 +1,31 @@
+@tool
+extends LabBody
+class_name Wire #TODO: Previous simulation already uses "ContactWire". Replace this when the old simulation is removed
+@export var texture: Texture2D
+@export var charge: Charge
+
+enum Charge{
+	POSITIVE,
+	NEGATIVE
+}
+
+signal moved() # Emits whenever the contact wire is moved
+
+var red_contact_wire: Texture2D = preload("res://updated_assets/icons_and_buttons/contact_positive.svg")
+var black_contact_wire: Texture2D = preload("res://updated_assets/icons_and_buttons/contact_negative.svg")
+var prev_pos: Vector2
+
+func _process(_delta: float) -> void:
+	if not Engine.is_editor_hint():
+		if position != prev_pos:
+			prev_pos = position
+			moved.emit()
+
+func _ready() -> void:
+	super()
+	prev_pos = position
+	$SelectableCanvasGroup/Sprite2D.texture = texture
+	if texture == red_contact_wire:
+		charge = Charge.POSITIVE
+	else:
+		charge = Charge.NEGATIVE

--- a/project/source/combined_scripts/contact_wire.gd.uid
+++ b/project/source/combined_scripts/contact_wire.gd.uid
@@ -1,0 +1,1 @@
+uid://bstdxu8mmw8e6

--- a/project/source/combined_scripts/contact_wires.gd
+++ b/project/source/combined_scripts/contact_wires.gd
@@ -1,0 +1,24 @@
+extends Node2D
+@export var power_supply: PowerSupply
+
+func _process(_delta: float) -> void:
+	if Interaction.active_drag_component and Interaction.active_drag_component.body is PowerSupply:
+		_on_moved()
+
+func _ready() -> void:
+	for contact_wire: Wire in get_children():
+		contact_wire.connect("moved", _on_moved)
+		
+func _draw() -> void:
+	draw_line($RedContactWire.position, $RedContactWire2.position, "black")
+	draw_line($BlackContactWire.position, $BlackContactWire2.position, "black")
+
+## Keep the wires on the top-most level whenever it moves. This accounts for when its moving 
+## While connected to the Power Supply
+func _on_moved() -> void:
+	# Check if the wires are already on the top-most level, if not remove and then re-add
+	if not self.get_index() == get_parent().get_child_count() - 1:
+		get_parent().call_deferred(&"remove_child", self)
+		get_parent().call_deferred(&"add_child", self)
+		
+	queue_redraw()

--- a/project/source/combined_scripts/contact_wires.gd.uid
+++ b/project/source/combined_scripts/contact_wires.gd.uid
@@ -1,0 +1,1 @@
+uid://qijnhs2e78qy

--- a/project/source/combined_scripts/lab_body.gd
+++ b/project/source/combined_scripts/lab_body.gd
@@ -32,6 +32,10 @@ func start_dragging() -> void:
 		p.set_deferred(&"collision_layer", 0)
 
 func stop_dragging() -> void:
+	# Contact wires will always be floating 
+	if is_in_group(&"contact_wire"):
+		return 
+		
 	set_deferred(&"collision_mask", 1)
 	set_deferred(&"freeze", false)
 

--- a/project/source/combined_scripts/power_supply.gd
+++ b/project/source/combined_scripts/power_supply.gd
@@ -1,5 +1,9 @@
 extends LabBody
 class_name PowerSupply
+
+# For simplicity sake, these will only toggle when the wire matches the outlet
+# It is technically possible to mismatch on both the power supply and gel rig and
+# the experiment will run just fine
 @export var positive_connected: bool = false
 @export var negative_connected: bool = false
 
@@ -13,7 +17,7 @@ func _on_start_button_pressed() -> void:
 	activate_power_supply.emit(180.0, 30, circuit_ready)
 
 
-func _on_wire_connected(wire: Wire, target_outlet_charge: Wire.Charge) -> void:		
+func _on_wire_connected(wire: Wire, target_outlet_charge: Wire.Charge) -> void:
 	var is_charge_matching: bool = wire.charge == target_outlet_charge
 	var is_outlet_positive: bool = target_outlet_charge == Wire.Charge.POSITIVE
 	
@@ -36,7 +40,7 @@ func _on_wire_connected(wire: Wire, target_outlet_charge: Wire.Charge) -> void:
 			wire_connected_to_negative_output = wire
 
 ## Handle unplugging wires from the Power Supply
-func unplug_handler(body: Node2D) -> void:		
+func unplug_handler(body: Node2D) -> void:
 	var clicked_on_wire: Wire = body
 	
 	if wire_connected_to_positive_output and clicked_on_wire == wire_connected_to_positive_output: # Pulling out the wire from positive outlet

--- a/project/source/combined_scripts/power_supply.gd
+++ b/project/source/combined_scripts/power_supply.gd
@@ -6,16 +6,61 @@ class_name PowerSupply
 # the experiment will run just fine
 @export var positive_connected: bool = false
 @export var negative_connected: bool = false
+@export var increment_time_button: TextureButton
+@export var decrement_time_button: TextureButton
+@export var increment_volts_button: TextureButton
+@export var decrement_volts_button: TextureButton
+
+@onready var button_function_dict: Dictionary = {
+	increment_time_button: {
+		"function": increment_time,
+		"type": ConfigType.TIME,
+	},
+	decrement_time_button: {
+		"function": decrement_time,
+		"type": ConfigType.TIME,
+	},
+	increment_volts_button: {
+		"function": increment_volts,
+		"type": ConfigType.VOLT,
+	},
+	decrement_volts_button: {
+		"function": decrement_volts,
+		"type": ConfigType.VOLT,
+	},
+}
 
 signal activate_power_supply(voltage: float, time: int, is_circuit_ready: bool)
 
-var wire_connected_to_positive_output: Wire
-var wire_connected_to_negative_output: Wire
+enum ConfigType{
+	TIME,
+	VOLT
+}
+
+var _wire_connected_to_positive_output: Wire
+var _wire_connected_to_negative_output: Wire
+var _is_zoomed_in: bool = false
+var _should_increment: bool = false
+var _time: int = 0 # Time in seconds
+var _volts: int = 50 
+var _buttons: Array[TextureButton]
+
+var _current_pressed_button: TextureButton
+var _delta_time: int = 1
+var _delta_volts: int = 1
+var _wait_time_threshold: float = .05
+
+func _ready() -> void:
+	$Screen/VoltageContainer/HBoxContainer/Volts.text = "%d" % [_volts]
+	Engine.max_fps = 60
+	for button: TextureButton in find_children("", "TextureButton", true):
+		_buttons.append(button)
+		button.button_down.connect(_on_screen_button_pressed.bind(button))
+		button.button_up.connect(_on_screen_button_released.bind(button))
 
 func _on_start_button_pressed() -> void:
 	var circuit_ready: bool = positive_connected and negative_connected
-	activate_power_supply.emit(180.0, 30, circuit_ready)
-
+	activate_power_supply.emit(_volts, _time, circuit_ready) #TODO stuff should happen once wires are connected to the gel rig
 
 func _on_wire_connected(wire: Wire, target_outlet_charge: Wire.Charge) -> void:
 	var is_charge_matching: bool = wire.charge == target_outlet_charge
@@ -24,31 +69,130 @@ func _on_wire_connected(wire: Wire, target_outlet_charge: Wire.Charge) -> void:
 	if is_charge_matching:
 		if is_outlet_positive:
 			positive_connected = true
-			wire_connected_to_positive_output = wire
+			_wire_connected_to_positive_output = wire
 			
 		else:
 			negative_connected = true
-			wire_connected_to_negative_output = wire
+			_wire_connected_to_negative_output = wire
 	
 	else:
 		if is_outlet_positive:
 			print("Connecting a Negative to a Positive!")
-			wire_connected_to_positive_output = wire
+			_wire_connected_to_positive_output = wire
 			
 		else:
 			print("Connecting a Positive to a Negative!")
-			wire_connected_to_negative_output = wire
+			_wire_connected_to_negative_output = wire
 
 ## Handle unplugging wires from the Power Supply
-func unplug_handler(body: Node2D) -> void:
+func _unplug_handler(body: Node2D) -> void:
 	var clicked_on_wire: Wire = body
 	
-	if wire_connected_to_positive_output and clicked_on_wire == wire_connected_to_positive_output: # Pulling out the wire from positive outlet
+	if _wire_connected_to_positive_output and clicked_on_wire == _wire_connected_to_positive_output: # Pulling out the wire from positive outlet
 		positive_connected = false
-		wire_connected_to_positive_output = null
+		_wire_connected_to_positive_output = null
 		
 		
-	elif wire_connected_to_negative_output and clicked_on_wire == wire_connected_to_negative_output: # Pulling out the wire from negative outlet
+	elif _wire_connected_to_negative_output and clicked_on_wire == _wire_connected_to_negative_output: # Pulling out the wire from negative outlet
 		negative_connected = false
-		wire_connected_to_negative_output = null
+		_wire_connected_to_negative_output = null
+
+func _input(event: InputEvent) -> void:
+	if event.is_action_pressed("ExitCameraZoom"):
+		_is_zoomed_in = false
+		for button in _buttons:
+			button.mouse_filter = Control.MOUSE_FILTER_IGNORE
+
+func _on_screen_input_event(_viewport: Node, event: InputEvent, _shape_idx: int) -> void:
+	if event.is_pressed():
+		TransitionCamera.target_camera = $ZoomCamera
+		_is_zoomed_in = true
+		for button in _buttons:
+			button.mouse_filter = Control.MOUSE_FILTER_STOP
+
+func _on_screen_mouse_entered() -> void:
+	$DragComponent.enable_interaction = false
+
+func _on_screen_mouse_exited() -> void:
+	if not _is_zoomed_in:
+		$DragComponent.enable_interaction = true
+ 
+func _on_timer_timeout() -> void:
+	var is_pressed: bool = _current_pressed_button.button_pressed
+	var button_function: Callable = button_function_dict[_current_pressed_button]["function"]
+	var config_type: ConfigType = button_function_dict[_current_pressed_button]["type"]
+	
+	if is_pressed and config_type == ConfigType.TIME:
+		gradually_change(button_function, config_type, 60)
+
+	elif is_pressed and config_type == ConfigType.VOLT:
+		gradually_change(button_function, config_type, 50)
 		
+func _on_screen_button_pressed(button: TextureButton) -> void:
+	_current_pressed_button = button
+	button_function_dict[_current_pressed_button]["function"].call() # Call once for single clicks
+	$Timer.start()
+
+func _on_screen_button_released(button: TextureButton) -> void:
+	$Timer.stop()
+	$Timer.wait_time = 0.15
+	_delta_time = 1
+	_delta_volts = 1
+	_should_increment = false
+	
+func increment_time() -> int:
+	_time += _delta_time
+	update_timer_display()
+	return _time
+	
+func decrement_time() -> int:
+	if _time > 0:
+		_time -= _delta_time
+		update_timer_display()
+	
+	return _time
+		
+func update_timer_display() -> void:
+	var minutes: int = _time / 60
+	var seconds: int = _time % 60
+	$Screen/TimeContainer/HBoxContainer/Time.text = "%d:%02d" % [minutes, seconds]
+
+func increment_volts() -> int:
+	_volts += _delta_volts
+	_volts = min(_volts, 999)
+	_update_volt_display()
+	
+	return _volts
+	
+func decrement_volts() -> int:
+	if _volts > 0:
+		_volts -= _delta_volts
+		_update_volt_display()
+	
+	return _volts
+	
+func _update_volt_display() -> void:
+	$Screen/VoltageContainer/HBoxContainer/Volts.text = "%d" % [_volts]
+
+func gradually_change(button_func: Callable, type: ConfigType, increment_value: int) -> void:
+	# Get either _time or _volts
+	var target_var_value: int = button_func.call()
+	
+	# Decrease the Timer's wait time to gradually increase the speed of changing values
+	if (target_var_value % increment_value != 0 or $Timer.wait_time > _wait_time_threshold) and not _should_increment:
+		$Timer.wait_time = max($Timer.wait_time - 0.0025, .05)
+	
+	# Start incrementing the value by a set amount
+	else:
+		_should_increment = true
+		$Timer.wait_time = .3 # Values change more slowly
+		$Timer.start() # Timer needs to start again to update the wait_time
+		change_delta_rate(type, increment_value)
+		
+## Updates the delta for time or volts to a set increment
+func change_delta_rate(type: ConfigType, new_delta: int) -> void:
+	if type == ConfigType.TIME:
+		_delta_time = new_delta 
+		
+	elif type == ConfigType.VOLT:
+		_delta_volts = new_delta

--- a/project/source/combined_scripts/power_supply.gd
+++ b/project/source/combined_scripts/power_supply.gd
@@ -1,0 +1,50 @@
+extends LabBody
+class_name PowerSupply
+@export var positive_connected: bool = false
+@export var negative_connected: bool = false
+
+signal activate_power_supply(voltage: float, time: int, is_circuit_ready: bool)
+
+var wire_connected_to_positive_output: Wire
+var wire_connected_to_negative_output: Wire
+
+func _on_start_button_pressed() -> void:
+	var circuit_ready: bool = positive_connected and negative_connected
+	activate_power_supply.emit(180.0, 30, circuit_ready)
+
+
+func _on_wire_connected(wire: Wire, target_outlet_charge: Wire.Charge) -> void:		
+	var is_charge_matching: bool = wire.charge == target_outlet_charge
+	var is_outlet_positive: bool = target_outlet_charge == Wire.Charge.POSITIVE
+	
+	if is_charge_matching:
+		if is_outlet_positive:
+			positive_connected = true
+			wire_connected_to_positive_output = wire
+			
+		else:
+			negative_connected = true
+			wire_connected_to_negative_output = wire
+	
+	else:
+		if is_outlet_positive:
+			print("Connecting a Negative to a Positive!")
+			wire_connected_to_positive_output = wire
+			
+		else:
+			print("Connecting a Positive to a Negative!")
+			wire_connected_to_negative_output = wire
+
+## Handle unplugging wires from the Power Supply
+func unplug_handler(body: Node2D) -> void:		
+	var clicked_on_wire: Wire = body
+	
+	if wire_connected_to_positive_output and clicked_on_wire == wire_connected_to_positive_output: # Pulling out the wire from positive outlet
+		positive_connected = false
+		wire_connected_to_positive_output = null
+		
+		
+	elif wire_connected_to_negative_output and clicked_on_wire == wire_connected_to_negative_output: # Pulling out the wire from negative outlet
+		negative_connected = false
+		wire_connected_to_negative_output = null
+		

--- a/project/source/combined_scripts/power_supply.gd.uid
+++ b/project/source/combined_scripts/power_supply.gd.uid
@@ -1,0 +1,1 @@
+uid://bepsdcjab3t21

--- a/project/source/project.godot
+++ b/project/source/project.godot
@@ -35,9 +35,11 @@ window/stretch/aspect="ignore"
 
 [global_group]
 
-Emptyable=""
 attachment:microcentrifuge_tube=""
 attachment:scoopula=""
+contact_wire=""
+emptyable=""
+attachment:contact_wire=""
 
 [gui]
 


### PR DESCRIPTION
- Contact wires can be attached to the positive or negative outlet of the power supply, if they're mismatched it will be printed to the console. If they are matching, a boolean flag on the power supply will indicate this.
- You can now input time and voltage on the power supply after zooming in on the screen, we might want to consider making the power supply itself bigger so we can more easily see and grab it.

Might add the ability to type in a number for input in the future.