### PR TITLE
Fix some empty container bugs

### DIFF
--- a/project/source/combined_scripts/container_component.gd
+++ b/project/source/combined_scripts/container_component.gd
@@ -60,7 +60,7 @@ func add(s: SubstanceInstance) -> void:
 # Total volume in the container, in mL.
 func get_total_volume() -> float:
 	return substances.map(func(s: SubstanceInstance) -> float: return s.get_volume()) \
-			.reduce(func(a: float, b: float) -> float: return a + b)
+			.reduce(func(a: float, b: float) -> float: return a + b, 0.0)
 
 # Take the given volume from the first substance.
 func take_volume(v: float) -> SubstanceInstance:

--- a/project/source/combined_scripts/microwave.gd
+++ b/project/source/combined_scripts/microwave.gd
@@ -96,8 +96,7 @@ func _on_microwave_stopped() -> void:
 				# container were full of only water.
 				var volume := container_to_heat.get_total_volume()
 				if volume > 0.0:
-					var temp_increase: float = 160.0 * (_total_seconds - _total_seconds_left) \
-						/ container_to_heat.get_total_volume()
+					var temp_increase: float = 160.0 * (_total_seconds - _total_seconds_left) / volume
 					container_to_heat.temperature += temp_increase
 
 		# Update _total_seconds for the next "start" press if the user doesn't clear

--- a/project/source/combined_scripts/microwave.gd
+++ b/project/source/combined_scripts/microwave.gd
@@ -94,9 +94,11 @@ func _on_microwave_stopped() -> void:
 				#
 				# This is very approximately equal to the amount of heating you would get if the
 				# container were full of only water.
-				var temp_increase: float = 160.0 * (_total_seconds - _total_seconds_left) \
-					/ container_to_heat.get_total_volume()
-				container_to_heat.temperature += temp_increase
+				var volume := container_to_heat.get_total_volume()
+				if volume > 0.0:
+					var temp_increase: float = 160.0 * (_total_seconds - _total_seconds_left) \
+						/ container_to_heat.get_total_volume()
+					container_to_heat.temperature += temp_increase
 
 		# Update _total_seconds for the next "start" press if the user doesn't clear
 		_total_seconds = _total_seconds_left


### PR DESCRIPTION
Resolves #374

This PR fixes a bug where calling `ContainerComponent.get_total_volume` would return null instead of zero for an empty container, and fixes a bug where the microwave would heat an empty container to an infinite temperature.