### PR TITLE
Add more ways to control which sprites are included in a ghost

### DIFF
--- a/project/source/combined_scripts/util.gd
+++ b/project/source/combined_scripts/util.gd
@@ -50,6 +50,12 @@ static func get_bounding_box(obj: CollisionObject2D) -> Rect2:
 	return rect
 
 static func _make_sprite_ghost_impl(node: Node2D) -> Node2D:
+	# Skip invisible nodes or ones in the "ghost:never_include" group. Never skip nodes in the
+	# "ghost:always_include" group.
+	if not node.is_in_group(&"ghost:always_include") \
+			and (not node.visible or node.is_in_group(&"ghost:never_include")):
+		return null
+
 	var new_node: Node2D = null
 	if node is Sprite2D:
 		new_node = Sprite2D.new()

--- a/project/source/project.godot
+++ b/project/source/project.godot
@@ -41,6 +41,8 @@ attachment:scoopula=""
 contact_wire=""
 emptyable=""
 attachment:contact_wire=""
+ghost:always_include="Always include this node in a sprite ghost (made via `Util.make_sprite_ghost`), regardless of visibility"
+ghost:never_include="Never include this node in a sprite ghost (made via `Util.make_sprite_ghost`), regardless of visibility"
 
 [gui]
 


### PR DESCRIPTION
Resolves #397

This PR makes the following changes to ghosts made with the `Util.make_sprite_ghost` function (used mainly by `AttachmentInteractableArea` to show where an object will be placed):
- If a node in a tree is invisible (i.e., `visible` is false), then it and its children will not be included in the ghost. This ensures that, for example, the pipette tip doesn't show up in the ghost if it's not visible.
- If a node in a scene is in the `ghost:never_include` group, then it and its children will never be included in the ghost, even if it is visible.
- If a node in a scene is in the `ghost:always_include` group, then it will always be included in a ghost, even if it is invisible. This can be used to make a custom ghost appearance that's not visible on the actual object.