### PR TITLE
Add a way to grey out interactions

### DIFF
--- a/project/source/Scripts/UI/Menu.gd
+++ b/project/source/Scripts/UI/Menu.gd
@@ -77,7 +77,7 @@ func _ready() -> void:
 	$%ResolutionDropdown.select(saved_resolution_index)
 	_on_resolution_dropdown_item_selected(saved_resolution_index)
 
-	_prompt_panel_stylebox_disallowed.set("bg_color", Color.SILVER)
+	_prompt_panel_stylebox_disallowed.bg_color.s *= 0.2
 
 func _process(delta: float) -> void:
 	if logs != []:
@@ -108,7 +108,9 @@ func _process(delta: float) -> void:
 
 			var label: Label = prompt_panel.get_node("Label")
 			label.text = "%s: %s" % [name, state.info.description]
-			var color: Color = Color.GRAY if state.is_pressed else Color.WHITE
+			var color: Color = Color.WHITE
+			if state.is_pressed or not state.info.allowed: color = Color.GRAY
+
 			label.add_theme_color_override(&"font_color", color)
 		else:
 			prompt_panel.hide()

--- a/project/source/Scripts/UI/Menu.gd
+++ b/project/source/Scripts/UI/Menu.gd
@@ -28,6 +28,8 @@ var _resolution_options: Array[Vector2i] = [
 	Vector2i(3840, 2160),
 ]
 
+@onready var _prompt_panel_stylebox_allowed: StyleBox = $%PrimaryPrompt.get_theme_stylebox("panel").duplicate()
+@onready var _prompt_panel_stylebox_disallowed: StyleBox = _prompt_panel_stylebox_allowed.duplicate()
 
 # Called when the node enters the scene tree for the first time.
 func _ready() -> void:
@@ -75,6 +77,8 @@ func _ready() -> void:
 	$%ResolutionDropdown.select(saved_resolution_index)
 	_on_resolution_dropdown_item_selected(saved_resolution_index)
 
+	_prompt_panel_stylebox_disallowed.set("bg_color", Color.SILVER)
+
 func _process(delta: float) -> void:
 	if logs != []:
 		# Need to display log message(s)
@@ -92,11 +96,16 @@ func _process(delta: float) -> void:
 	for b in buttons:
 		var kind: InteractInfo.Kind = b[0]
 		var name: String = b[1]
-		var prompt_panel: Control = b[2]
+		var prompt_panel: PanelContainer = b[2]
 
 		var state: Interaction.InteractState = Interaction.interactions.get(kind)
 		if state.info:
 			prompt_panel.show()
+			if state.info.allowed:
+				prompt_panel.add_theme_stylebox_override("panel", _prompt_panel_stylebox_allowed)
+			else:
+				prompt_panel.add_theme_stylebox_override("panel", _prompt_panel_stylebox_disallowed)
+
 			var label: Label = prompt_panel.get_node("Label")
 			label.text = "%s: %s" % [name, state.info.description]
 			var color: Color = Color.GRAY if state.is_pressed else Color.WHITE

--- a/project/source/Scripts/UI/Menu.gd
+++ b/project/source/Scripts/UI/Menu.gd
@@ -78,6 +78,7 @@ func _ready() -> void:
 	_on_resolution_dropdown_item_selected(saved_resolution_index)
 
 	_prompt_panel_stylebox_disallowed.bg_color.s *= 0.2
+	_prompt_panel_stylebox_disallowed.bg_color *= 0.5
 
 func _process(delta: float) -> void:
 	if logs != []:

--- a/project/source/combined_scripts/interact_info.gd
+++ b/project/source/combined_scripts/interact_info.gd
@@ -15,7 +15,15 @@ var kind: Kind = Kind.PRIMARY
 ## Displayed in the button prompt.
 var description: String = ""
 
+## If this is set to [code]false[/code], then this interaction can be [i]targeted[/i], but pressing
+## the button will not do anything. Setting this to [code]false[/code] will [i]also[/i] show a
+## greyed out button prompt. As an example, the pipette can't interact with the pipette tip box when
+## it already has a tip, so it's better to show a greyed out button prompt that says something like
+## "Left click: Add tip (already has tip).
+var allowed: bool = true
 
-func _init(p_kind: Kind, p_description: String) -> void:
+
+func _init(p_kind: Kind, p_description: String, p_allowed: bool = true) -> void:
 	kind = p_kind
 	description = p_description
+	allowed = p_allowed

--- a/project/source/combined_scripts/interaction_singleton.gd
+++ b/project/source/combined_scripts/interaction_singleton.gd
@@ -37,14 +37,14 @@ class InteractState:
 
 	func start_interact() -> void:
 		is_pressed = true
-		if not info: return
+		if not info or not info.allowed: return
 		if source: source.start_use(target as InteractableArea, info.kind)
 		elif target is InteractableArea or target is InteractableComponent or target is LabBody:
 			target.start_interact(info.kind)
 
 	func stop_interact() -> void:
 		is_pressed = false
-		if not info: return
+		if not info or not info.allowed: return
 		if source: source.stop_use(target as InteractableArea, info.kind)
 		elif target is InteractableArea or target is InteractableComponent or target is LabBody:
 			target.stop_interact(info.kind)

--- a/project/source/combined_scripts/pipette_box_interactable_area.gd
+++ b/project/source/combined_scripts/pipette_box_interactable_area.gd
@@ -1,16 +1,17 @@
 extends InteractableArea
 
-var info: InteractInfo = InteractInfo.new(InteractInfo.Kind.PRIMARY, "Add Tip")
-var pipette: LabBody = null
+var _info: InteractInfo = InteractInfo.new(InteractInfo.Kind.PRIMARY, "Add Tip")
+var _disallowed_info: InteractInfo = InteractInfo.new(InteractInfo.Kind.PRIMARY, "(Tip is already attached)", false)
 
 func get_interactions() -> Array[InteractInfo]:
 	if Interaction.held_body is Pipe:
-		return [info]
-	
+		if Interaction.held_body.has_tip: return [_disallowed_info]
+		else: return [_info]
+
 	return []
-	
+
 func start_interact(_kind: InteractInfo.Kind) -> void:
-	pipette = Interaction.held_body 
+	var pipette: Pipe = Interaction.held_body
 	if pipette.has_tip:
 		print("Pipette already has a tip!")
 		return

--- a/project/source/combined_scripts/pipette_box_interactable_area.gd
+++ b/project/source/combined_scripts/pipette_box_interactable_area.gd
@@ -1,7 +1,7 @@
 extends InteractableArea
 
 var _info: InteractInfo = InteractInfo.new(InteractInfo.Kind.PRIMARY, "Add Tip")
-var _disallowed_info: InteractInfo = InteractInfo.new(InteractInfo.Kind.PRIMARY, "(Tip is already attached)", false)
+var _disallowed_info: InteractInfo = InteractInfo.new(InteractInfo.Kind.PRIMARY, "Add Tip (Pipette already has a tip)", false)
 
 func get_interactions() -> Array[InteractInfo]:
 	if Interaction.held_body is Pipe:
@@ -12,9 +12,5 @@ func get_interactions() -> Array[InteractInfo]:
 
 func start_interact(_kind: InteractInfo.Kind) -> void:
 	var pipette: Pipe = Interaction.held_body
-	if pipette.has_tip:
-		print("Pipette already has a tip!")
-		return
-	
 	pipette.has_tip = true
 	pipette.is_tip_contaminated = false


### PR DESCRIPTION
Resolves #394

Depends on #390 because it would otherwise be very annoying to rebase or merge these changes.

Adds a member to `InteractInfo` called `allowed`. When `allowed` is set to `false`, the button prompt will be greyed out and `start_interact` and `stop_interact` will never be called. This PR adds a greyed out prompt to the pipette box when the pipette already has a tip.